### PR TITLE
fix(deps): downgrade Microsoft.Extensions packages to .NET 8 versions

### DIFF
--- a/src/backend/src/FantasyRealm.Infrastructure/FantasyRealm.Infrastructure.csproj
+++ b/src/backend/src/FantasyRealm.Infrastructure/FantasyRealm.Infrastructure.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="MailKit" Version="4.14.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.1.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
   </ItemGroup>

--- a/src/backend/tests/FantasyRealm.Tests.Integration/FantasyRealm.Tests.Integration.csproj
+++ b/src/backend/tests/FantasyRealm.Tests.Integration/FantasyRealm.Tests.Integration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Testcontainers.MongoDb" Version="4.9.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />


### PR DESCRIPTION
- Microsoft.Extensions.Options.ConfigurationExtensions: 10.0.0 → 8.0.0
- Microsoft.Extensions.Configuration.UserSecrets: 10.0.0 → 8.0.1

Version 10.x packages are designed for .NET 10 and cause assembly version conflicts when used with .NET 8 target framework.