### PR TITLE
ci: add railway.toml to skip build until deployment US

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,10 @@
+# Railway configuration
+# Backend deployment will be configured in a future US
+# For now, skip automatic builds to prevent CI failures
+
+[build]
+builder = "nixpacks"
+buildCommand = "echo 'Backend deployment not configured yet - skipping build'"
+
+[deploy]
+startCommand = "echo 'Backend not deployed' && sleep infinity"


### PR DESCRIPTION
Prevents Railway from failing on auto-detection of the monorepo. Backend deployment configuration will be done in dedicated US.