### PR TITLE
fix(ci): add fetch-depth: 0 for paths-filter to work on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect file changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Without full git history, paths-filter cannot compute the diff between commits on push events and marks all filters as false, causing builds to be skipped incorrectly.