### PR TITLE
feat: Référentiels de jeu - classes et slots d'équipement (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ docker-compose.override.yml
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .vercel
 .playwright-mcp
+src/frontend/.vite

--- a/database/sql/003_create_reference_tables.sql
+++ b/database/sql/003_create_reference_tables.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- Migration: Create game reference tables (character classes & equipment slots)
+-- ============================================================================
+
+-- Character classes reference table
+CREATE TABLE character_classes (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(20) NOT NULL,
+    description TEXT NOT NULL,
+    icon_url VARCHAR(255),
+    CONSTRAINT uq_character_classes_name UNIQUE (name)
+);
+
+-- Equipment slots reference table
+CREATE TABLE equipment_slots (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(30) NOT NULL,
+    display_order INT NOT NULL,
+    CONSTRAINT uq_equipment_slots_name UNIQUE (name)
+);
+
+-- Seed character classes (4 classes)
+INSERT INTO character_classes (name, description) VALUES
+    ('Guerrier', 'Un combattant robuste qui excelle au corps à corps et peut porter des armures lourdes.'),
+    ('Mage', 'Un puissant lanceur de sorts qui manie la magie des arcanes mais porte des armures légères.'),
+    ('Archer', 'Un combattant à distance agile doté d''une précision mortelle et d''une armure intermédiaire.'),
+    ('Voleur', 'Un assassin furtif qui frappe depuis les ombres avec des attaques rapides.');
+
+-- Seed equipment slots (14 slots, WoW-inspired)
+INSERT INTO equipment_slots (name, display_order) VALUES
+    ('Tête', 1),
+    ('Épaules', 2),
+    ('Dos', 3),
+    ('Torse', 4),
+    ('Poignets', 5),
+    ('Mains', 6),
+    ('Taille', 7),
+    ('Jambes', 8),
+    ('Pieds', 9),
+    ('Cou', 10),
+    ('Anneau 1', 11),
+    ('Anneau 2', 12),
+    ('Main droite', 13),
+    ('Main gauche', 14);

--- a/src/backend/src/FantasyRealm.Api/Controllers/ReferenceDataController.cs
+++ b/src/backend/src/FantasyRealm.Api/Controllers/ReferenceDataController.cs
@@ -1,0 +1,54 @@
+using FantasyRealm.Application.DTOs;
+using FantasyRealm.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FantasyRealm.Api.Controllers
+{
+    /// <summary>
+    /// Controller for game reference data (character classes, equipment slots).
+    /// </summary>
+    [ApiController]
+    [Route("api")]
+    public sealed class ReferenceDataController(IReferenceDataService referenceDataService) : ControllerBase
+    {
+        /// <summary>
+        /// Returns all available character classes.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of character classes.</returns>
+        /// <response code="200">Character classes retrieved successfully.</response>
+        [HttpGet("character-classes")]
+        [ProducesResponseType(typeof(IReadOnlyList<CharacterClassResponse>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetCharacterClasses(CancellationToken cancellationToken)
+        {
+            var result = await referenceDataService.GetCharacterClassesAsync(cancellationToken);
+
+            if (result.IsFailure)
+            {
+                return StatusCode(result.ErrorCode ?? 500, new { message = result.Error });
+            }
+
+            return Ok(result.Value);
+        }
+
+        /// <summary>
+        /// Returns all equipment slots ordered by display order.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>A list of equipment slots.</returns>
+        /// <response code="200">Equipment slots retrieved successfully.</response>
+        [HttpGet("equipment-slots")]
+        [ProducesResponseType(typeof(IReadOnlyList<EquipmentSlotResponse>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetEquipmentSlots(CancellationToken cancellationToken)
+        {
+            var result = await referenceDataService.GetEquipmentSlotsAsync(cancellationToken);
+
+            if (result.IsFailure)
+            {
+                return StatusCode(result.ErrorCode ?? 500, new { message = result.Error });
+            }
+
+            return Ok(result.Value);
+        }
+    }
+}

--- a/src/backend/src/FantasyRealm.Application/DTOs/CharacterClassResponse.cs
+++ b/src/backend/src/FantasyRealm.Application/DTOs/CharacterClassResponse.cs
@@ -1,0 +1,15 @@
+namespace FantasyRealm.Application.DTOs
+{
+    /// <summary>
+    /// Response payload for a character class.
+    /// </summary>
+    /// <param name="Id">The unique identifier.</param>
+    /// <param name="Name">The class name (e.g. Warrior, Mage).</param>
+    /// <param name="Description">A short description of the class.</param>
+    /// <param name="IconUrl">Optional URL to the class icon.</param>
+    public sealed record CharacterClassResponse(
+        int Id,
+        string Name,
+        string Description,
+        string? IconUrl);
+}

--- a/src/backend/src/FantasyRealm.Application/DTOs/EquipmentSlotResponse.cs
+++ b/src/backend/src/FantasyRealm.Application/DTOs/EquipmentSlotResponse.cs
@@ -1,0 +1,13 @@
+namespace FantasyRealm.Application.DTOs
+{
+    /// <summary>
+    /// Response payload for an equipment slot.
+    /// </summary>
+    /// <param name="Id">The unique identifier.</param>
+    /// <param name="Name">The slot name (e.g. Head, Chest, MainHand).</param>
+    /// <param name="DisplayOrder">The display order for UI rendering.</param>
+    public sealed record EquipmentSlotResponse(
+        int Id,
+        string Name,
+        int DisplayOrder);
+}

--- a/src/backend/src/FantasyRealm.Application/Interfaces/IReferenceDataRepository.cs
+++ b/src/backend/src/FantasyRealm.Application/Interfaces/IReferenceDataRepository.cs
@@ -1,0 +1,20 @@
+using FantasyRealm.Domain.Entities;
+
+namespace FantasyRealm.Application.Interfaces
+{
+    /// <summary>
+    /// Repository contract for game reference data (character classes, equipment slots).
+    /// </summary>
+    public interface IReferenceDataRepository
+    {
+        /// <summary>
+        /// Returns all character classes.
+        /// </summary>
+        Task<IReadOnlyList<CharacterClass>> GetAllClassesAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns all equipment slots ordered by display order.
+        /// </summary>
+        Task<IReadOnlyList<EquipmentSlot>> GetAllSlotsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/backend/src/FantasyRealm.Application/Interfaces/IReferenceDataService.cs
+++ b/src/backend/src/FantasyRealm.Application/Interfaces/IReferenceDataService.cs
@@ -1,0 +1,21 @@
+using FantasyRealm.Application.Common;
+using FantasyRealm.Application.DTOs;
+
+namespace FantasyRealm.Application.Interfaces
+{
+    /// <summary>
+    /// Service contract for game reference data (character classes, equipment slots).
+    /// </summary>
+    public interface IReferenceDataService
+    {
+        /// <summary>
+        /// Returns all available character classes.
+        /// </summary>
+        Task<Result<IReadOnlyList<CharacterClassResponse>>> GetCharacterClassesAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Returns all equipment slots ordered by display order.
+        /// </summary>
+        Task<Result<IReadOnlyList<EquipmentSlotResponse>>> GetEquipmentSlotsAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/backend/src/FantasyRealm.Application/Services/ReferenceDataService.cs
+++ b/src/backend/src/FantasyRealm.Application/Services/ReferenceDataService.cs
@@ -1,0 +1,36 @@
+using FantasyRealm.Application.Common;
+using FantasyRealm.Application.DTOs;
+using FantasyRealm.Application.Interfaces;
+
+namespace FantasyRealm.Application.Services
+{
+    /// <summary>
+    /// Provides read access to game reference data.
+    /// </summary>
+    public sealed class ReferenceDataService(IReferenceDataRepository repository) : IReferenceDataService
+    {
+        /// <inheritdoc />
+        public async Task<Result<IReadOnlyList<CharacterClassResponse>>> GetCharacterClassesAsync(CancellationToken cancellationToken)
+        {
+            var classes = await repository.GetAllClassesAsync(cancellationToken);
+
+            var response = classes
+                .Select(c => new CharacterClassResponse(c.Id, c.Name, c.Description, c.IconUrl))
+                .ToList() as IReadOnlyList<CharacterClassResponse>;
+
+            return Result<IReadOnlyList<CharacterClassResponse>>.Success(response);
+        }
+
+        /// <inheritdoc />
+        public async Task<Result<IReadOnlyList<EquipmentSlotResponse>>> GetEquipmentSlotsAsync(CancellationToken cancellationToken)
+        {
+            var slots = await repository.GetAllSlotsAsync(cancellationToken);
+
+            var response = slots
+                .Select(s => new EquipmentSlotResponse(s.Id, s.Name, s.DisplayOrder))
+                .ToList() as IReadOnlyList<EquipmentSlotResponse>;
+
+            return Result<IReadOnlyList<EquipmentSlotResponse>>.Success(response);
+        }
+    }
+}

--- a/src/backend/src/FantasyRealm.Domain/Entities/CharacterClass.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/CharacterClass.cs
@@ -1,0 +1,16 @@
+namespace FantasyRealm.Domain.Entities
+{
+    /// <summary>
+    /// Represents a playable character class (e.g. Warrior, Mage, Archer, Rogue).
+    /// </summary>
+    public class CharacterClass
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public string Description { get; set; } = string.Empty;
+
+        public string? IconUrl { get; set; }
+    }
+}

--- a/src/backend/src/FantasyRealm.Domain/Entities/EquipmentSlot.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/EquipmentSlot.cs
@@ -1,0 +1,14 @@
+namespace FantasyRealm.Domain.Entities
+{
+    /// <summary>
+    /// Represents an equipment slot where articles can be equipped (e.g. Head, Chest, MainHand).
+    /// </summary>
+    public class EquipmentSlot
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public int DisplayOrder { get; set; }
+    }
+}

--- a/src/backend/src/FantasyRealm.Infrastructure/DependencyInjection.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/DependencyInjection.cs
@@ -55,6 +55,8 @@ namespace FantasyRealm.Infrastructure
             services.AddSingleton<IPasswordGenerator, SecurePasswordGenerator>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IContactService, ContactService>();
+            services.AddScoped<IReferenceDataRepository, ReferenceDataRepository>();
+            services.AddScoped<IReferenceDataService, ReferenceDataService>();
 
             return services;
         }

--- a/src/backend/src/FantasyRealm.Infrastructure/Persistence/FantasyRealmDbContext.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/Persistence/FantasyRealmDbContext.cs
@@ -23,6 +23,10 @@ namespace FantasyRealm.Infrastructure.Persistence
 
         public DbSet<Comment> Comments { get; set; } = null!;
 
+        public DbSet<CharacterClass> CharacterClasses { get; set; } = null!;
+
+        public DbSet<EquipmentSlot> EquipmentSlots { get; set; } = null!;
+
         protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
         {
             base.ConfigureConventions(configurationBuilder);
@@ -41,6 +45,8 @@ namespace FantasyRealm.Infrastructure.Persistence
             ConfigureArticle(modelBuilder);
             ConfigureCharacterArticle(modelBuilder);
             ConfigureComment(modelBuilder);
+            ConfigureCharacterClass(modelBuilder);
+            ConfigureEquipmentSlot(modelBuilder);
 
             modelBuilder.ApplySnakeCaseNamingConvention();
         }
@@ -172,6 +178,31 @@ namespace FantasyRealm.Infrastructure.Persistence
                       .WithMany(u => u.Comments)
                       .HasForeignKey(e => e.AuthorId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+        }
+
+        private static void ConfigureCharacterClass(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CharacterClass>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Name).HasMaxLength(20).IsRequired();
+                entity.Property(e => e.Description).IsRequired();
+                entity.Property(e => e.IconUrl).HasMaxLength(255);
+
+                entity.HasIndex(e => e.Name).IsUnique();
+            });
+        }
+
+        private static void ConfigureEquipmentSlot(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<EquipmentSlot>(entity =>
+            {
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Name).HasMaxLength(30).IsRequired();
+                entity.Property(e => e.DisplayOrder).IsRequired();
+
+                entity.HasIndex(e => e.Name).IsUnique();
             });
         }
     }

--- a/src/backend/src/FantasyRealm.Infrastructure/Repositories/ReferenceDataRepository.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/Repositories/ReferenceDataRepository.cs
@@ -1,0 +1,31 @@
+using FantasyRealm.Application.Interfaces;
+using FantasyRealm.Domain.Entities;
+using FantasyRealm.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FantasyRealm.Infrastructure.Repositories
+{
+    /// <summary>
+    /// Provides read access to game reference data from PostgreSQL.
+    /// </summary>
+    public sealed class ReferenceDataRepository(FantasyRealmDbContext context) : IReferenceDataRepository
+    {
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<CharacterClass>> GetAllClassesAsync(CancellationToken cancellationToken)
+        {
+            return await context.CharacterClasses
+                .AsNoTracking()
+                .OrderBy(c => c.Name)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<EquipmentSlot>> GetAllSlotsAsync(CancellationToken cancellationToken)
+        {
+            return await context.EquipmentSlots
+                .AsNoTracking()
+                .OrderBy(s => s.DisplayOrder)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/src/backend/tests/FantasyRealm.Tests.Integration/Controllers/ReferenceDataControllerIntegrationTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Integration/Controllers/ReferenceDataControllerIntegrationTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+
+namespace FantasyRealm.Tests.Integration.Controllers
+{
+    /// <summary>
+    /// Integration tests for the reference data endpoints (character classes and equipment slots).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    [Trait("Category", "ReferenceData")]
+    public class ReferenceDataControllerIntegrationTests : IClassFixture<FantasyRealmWebApplicationFactory>
+    {
+        private readonly HttpClient _client;
+
+        public ReferenceDataControllerIntegrationTests(FantasyRealmWebApplicationFactory factory)
+        {
+            _client = factory.CreateClient();
+        }
+
+        private sealed record CharacterClassDto(int Id, string Name, string Description, string? IconUrl);
+
+        private sealed record EquipmentSlotDto(int Id, string Name, int DisplayOrder);
+
+        [Fact]
+        public async Task GetCharacterClasses_ReturnsOkWithFourClasses()
+        {
+            var response = await _client.GetAsync("/api/character-classes");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var classes = await response.Content.ReadFromJsonAsync<List<CharacterClassDto>>();
+            classes.Should().NotBeNull();
+            classes.Should().HaveCount(4);
+            classes!.Select(c => c.Name).Should().BeEquivalentTo(["Archer", "Guerrier", "Mage", "Voleur"]);
+        }
+
+        [Fact]
+        public async Task GetCharacterClasses_ReturnsClassesWithDescriptions()
+        {
+            var response = await _client.GetAsync("/api/character-classes");
+            var classes = await response.Content.ReadFromJsonAsync<List<CharacterClassDto>>();
+
+            classes.Should().AllSatisfy(c =>
+            {
+                c.Id.Should().BeGreaterThan(0);
+                c.Name.Should().NotBeNullOrWhiteSpace();
+                c.Description.Should().NotBeNullOrWhiteSpace();
+            });
+        }
+
+        [Fact]
+        public async Task GetEquipmentSlots_ReturnsOkWithFourteenSlots()
+        {
+            var response = await _client.GetAsync("/api/equipment-slots");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            var slots = await response.Content.ReadFromJsonAsync<List<EquipmentSlotDto>>();
+            slots.Should().NotBeNull();
+            slots.Should().HaveCount(14);
+        }
+
+        [Fact]
+        public async Task GetEquipmentSlots_ReturnsSlotsOrderedByDisplayOrder()
+        {
+            var response = await _client.GetAsync("/api/equipment-slots");
+            var slots = await response.Content.ReadFromJsonAsync<List<EquipmentSlotDto>>();
+
+            slots.Should().NotBeNull();
+            slots!.Select(s => s.DisplayOrder).Should().BeInAscendingOrder();
+            slots.First().Name.Should().Be("Tête");
+            slots.Last().Name.Should().Be("Main gauche");
+        }
+
+        [Fact]
+        public async Task GetEquipmentSlots_ReturnsExpectedSlotNames()
+        {
+            var response = await _client.GetAsync("/api/equipment-slots");
+            var slots = await response.Content.ReadFromJsonAsync<List<EquipmentSlotDto>>();
+
+            var expectedNames = new[]
+            {
+                "Tête", "Épaules", "Dos", "Torse", "Poignets", "Mains", "Taille",
+                "Jambes", "Pieds", "Cou", "Anneau 1", "Anneau 2", "Main droite", "Main gauche"
+            };
+
+            slots!.Select(s => s.Name).Should().BeEquivalentTo(expectedNames);
+        }
+    }
+}

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Services/ReferenceDataServiceTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Services/ReferenceDataServiceTests.cs
@@ -1,0 +1,91 @@
+using FantasyRealm.Application.Interfaces;
+using FantasyRealm.Application.Services;
+using FantasyRealm.Domain.Entities;
+using FluentAssertions;
+using Moq;
+
+namespace FantasyRealm.Tests.Unit.Services
+{
+    /// <summary>
+    /// Unit tests for <see cref="ReferenceDataService"/>.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Category", "ReferenceData")]
+    public class ReferenceDataServiceTests
+    {
+        private readonly Mock<IReferenceDataRepository> _repositoryMock = new();
+        private readonly ReferenceDataService _sut;
+
+        public ReferenceDataServiceTests()
+        {
+            _sut = new ReferenceDataService(_repositoryMock.Object);
+        }
+
+        [Fact]
+        public async Task GetCharacterClassesAsync_ReturnsMappedClasses()
+        {
+            var classes = new List<CharacterClass>
+            {
+                new() { Id = 1, Name = "Warrior", Description = "A melee fighter.", IconUrl = null },
+                new() { Id = 2, Name = "Mage", Description = "A spellcaster.", IconUrl = "https://cdn.example.com/mage.png" }
+            };
+            _repositoryMock.Setup(r => r.GetAllClassesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(classes);
+
+            var result = await _sut.GetCharacterClassesAsync(CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().HaveCount(2);
+            result.Value![0].Id.Should().Be(1);
+            result.Value[0].Name.Should().Be("Warrior");
+            result.Value[0].Description.Should().Be("A melee fighter.");
+            result.Value[0].IconUrl.Should().BeNull();
+            result.Value[1].IconUrl.Should().Be("https://cdn.example.com/mage.png");
+        }
+
+        [Fact]
+        public async Task GetCharacterClassesAsync_WhenEmpty_ReturnsEmptyList()
+        {
+            _repositoryMock.Setup(r => r.GetAllClassesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<CharacterClass>());
+
+            var result = await _sut.GetCharacterClassesAsync(CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task GetEquipmentSlotsAsync_ReturnsMappedSlots()
+        {
+            var slots = new List<EquipmentSlot>
+            {
+                new() { Id = 1, Name = "Head", DisplayOrder = 1 },
+                new() { Id = 2, Name = "Shoulders", DisplayOrder = 2 },
+                new() { Id = 3, Name = "Chest", DisplayOrder = 4 }
+            };
+            _repositoryMock.Setup(r => r.GetAllSlotsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(slots);
+
+            var result = await _sut.GetEquipmentSlotsAsync(CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().HaveCount(3);
+            result.Value![0].Name.Should().Be("Head");
+            result.Value![0].DisplayOrder.Should().Be(1);
+            result.Value![2].Name.Should().Be("Chest");
+        }
+
+        [Fact]
+        public async Task GetEquipmentSlotsAsync_WhenEmpty_ReturnsEmptyList()
+        {
+            _repositoryMock.Setup(r => r.GetAllSlotsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<EquipmentSlot>());
+
+            var result = await _sut.GetEquipmentSlotsAsync(CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEmpty();
+        }
+    }
+}

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -1884,6 +1884,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",

--- a/src/frontend/src/services/referenceDataService.ts
+++ b/src/frontend/src/services/referenceDataService.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './api';
+
+export interface CharacterClass {
+  id: number;
+  name: string;
+  description: string;
+  iconUrl: string | null;
+}
+
+export interface EquipmentSlot {
+  id: number;
+  name: string;
+  displayOrder: number;
+}
+
+export const fetchCharacterClasses = (): Promise<CharacterClass[]> =>
+  apiClient.get<CharacterClass[]>('/character-classes');
+
+export const fetchEquipmentSlots = (): Promise<EquipmentSlot[]> =>
+  apiClient.get<EquipmentSlot[]>('/equipment-slots');


### PR DESCRIPTION
## Summary

- Ajout des entités `CharacterClass` et `EquipmentSlot` avec stack Clean Architecture complète (Domain, Application, Infrastructure, API)
- Endpoints publics `GET /api/character-classes` et `GET /api/equipment-slots`
- Script SQL `003_create_reference_tables.sql` avec seed de 4 classes et 14 slots en français
- 4 tests unitaires + 5 tests d'intégration
- Service frontend `referenceDataService.ts` avec types TypeScript

## Test plan

- [x] `dotnet build` → 0 erreur
- [x] `dotnet test` → 174 tests (121 unit + 53 intégration)
- [x] `tsc --noEmit` → OK
- [x] `npm run build` → OK
- [x] `npm run test` → 270 tests