### PR TITLE
fix(database): add self-registration to migration scripts (#106)

### DIFF
--- a/database/sql/001_create_tables.sql
+++ b/database/sql/001_create_tables.sql
@@ -103,3 +103,8 @@ CREATE TABLE comments (
 CREATE INDEX idx_comments_character_id ON comments(character_id);
 CREATE INDEX idx_comments_author_id ON comments(author_id);
 CREATE INDEX idx_comments_pending ON comments(character_id) WHERE status = 'pending';
+
+-- Record migration
+INSERT INTO migration_history (filename, checksum, execution_time_ms, applied_by)
+VALUES ('001_create_tables.sql', 'v1', 0, 'manual')
+ON CONFLICT (filename) DO NOTHING;

--- a/database/sql/002_add_user_audit_columns.sql
+++ b/database/sql/002_add_user_audit_columns.sql
@@ -20,3 +20,8 @@ CREATE TRIGGER trigger_users_updated_at
     BEFORE UPDATE ON users
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
+
+-- Record migration
+INSERT INTO migration_history (filename, checksum, execution_time_ms, applied_by)
+VALUES ('002_add_user_audit_columns.sql', 'v1', 0, 'manual')
+ON CONFLICT (filename) DO NOTHING;

--- a/database/sql/003_create_reference_tables.sql
+++ b/database/sql/003_create_reference_tables.sql
@@ -42,3 +42,8 @@ INSERT INTO equipment_slots (name, display_order) VALUES
     ('Anneau 2', 12),
     ('Main droite', 13),
     ('Main gauche', 14);
+
+-- Record migration
+INSERT INTO migration_history (filename, checksum, execution_time_ms, applied_by)
+VALUES ('003_create_reference_tables.sql', 'v1', 0, 'manual')
+ON CONFLICT (filename) DO NOTHING;

--- a/database/sql/004_evolve_characters_table.sql
+++ b/database/sql/004_evolve_characters_table.sql
@@ -31,3 +31,8 @@ CREATE INDEX idx_characters_gallery ON characters(is_shared, status)
 
 -- Index for filtering by status (moderation views)
 CREATE INDEX idx_characters_status ON characters(status);
+
+-- Record migration
+INSERT INTO migration_history (filename, checksum, execution_time_ms, applied_by)
+VALUES ('004_evolve_characters_table.sql', 'v1', 0, 'manual')
+ON CONFLICT (filename) DO NOTHING;


### PR DESCRIPTION
Each migration script now inserts itself into migration_history table when executed, using ON CONFLICT DO NOTHING for idempotency.