### PR TITLE
feat(frontend): add employee moderation dashboard (#69)

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
-import { HomePage, RegisterPage, LoginPage, ForgotPasswordPage, DashboardPage, ContactPage, UnauthorizedPage, CreateCharacterPage, EditCharacterPage, CharacterDetailPage, GalleryPage, LegalPage } from './pages';
+import { HomePage, RegisterPage, LoginPage, ForgotPasswordPage, DashboardPage, ContactPage, UnauthorizedPage, CreateCharacterPage, EditCharacterPage, CharacterDetailPage, GalleryPage, LegalPage, ModerationPage } from './pages';
 import { ProtectedRoute } from './components/auth';
 
 function App() {
@@ -14,6 +14,7 @@ function App() {
       <Route path="/characters/:id/edit" element={<ProtectedRoute requiredRole="User"><EditCharacterPage /></ProtectedRoute>} />
       <Route path="/characters/:id" element={<CharacterDetailPage />} />
       <Route path="/galerie" element={<GalleryPage />} />
+      <Route path="/moderation" element={<ProtectedRoute requiredRole="Employee"><ModerationPage /></ProtectedRoute>} />
       <Route path="/contact" element={<ContactPage />} />
       <Route path="/mentions-legales" element={<LegalPage slug="mentions-legales" />} />
       <Route path="/cgu" element={<LegalPage slug="cgu" />} />

--- a/src/frontend/src/components/layout/Header.tsx
+++ b/src/frontend/src/components/layout/Header.tsx
@@ -119,16 +119,19 @@ const Header = () => {
                       Paramètres
                     </Link>
                     {(user?.role === 'Employee' || user?.role === 'Admin') && (
-                      <Link
-                        to="/moderation"
-                        className="flex items-center gap-2 px-4 py-2 text-sm text-cream-300 hover:bg-dark-700 hover:text-cream-100 transition-colors"
-                        onClick={() => setIsDropdownOpen(false)}
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        </svg>
-                        Modération
-                      </Link>
+                      <>
+                        <div className="border-t border-dark-700 my-1" />
+                        <Link
+                          to="/moderation"
+                          className="flex items-center gap-2 px-4 py-2 text-sm text-cream-300 hover:bg-dark-700 hover:text-cream-100 transition-colors"
+                          onClick={() => setIsDropdownOpen(false)}
+                        >
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                          </svg>
+                          Modération
+                        </Link>
+                      </>
                     )}
                     {user?.role === 'Admin' && (
                       <Link
@@ -251,13 +254,16 @@ const Header = () => {
                     Paramètres
                   </Link>
                   {(user?.role === 'Employee' || user?.role === 'Admin') && (
-                    <Link
-                      to="/moderation"
-                      className="px-4 py-2 text-sm text-cream-300 hover:bg-dark-800 rounded-lg transition-colors"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      Modération
-                    </Link>
+                    <>
+                      <div className="border-t border-dark-700 my-1" />
+                      <Link
+                        to="/moderation"
+                        className="px-4 py-2 text-sm text-cream-300 hover:bg-dark-800 rounded-lg transition-colors"
+                        onClick={() => setIsMenuOpen(false)}
+                      >
+                        Modération
+                      </Link>
+                    </>
                   )}
                   {user?.role === 'Admin' && (
                     <Link
@@ -268,6 +274,7 @@ const Header = () => {
                       Administration
                     </Link>
                   )}
+                  <div className="border-t border-dark-700 my-1" />
                   <button
                     type="button"
                     onClick={handleLogout}

--- a/src/frontend/src/components/moderation/ModerationCard.tsx
+++ b/src/frontend/src/components/moderation/ModerationCard.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import type { PendingCharacter } from '../../types';
+import { MiniPreview } from '../character/MiniPreview';
+import { CLASS_ICONS } from '../ui/icons';
+import { Button } from '../ui';
+import { formatRelativeDate } from '../../utils/formatRelativeDate';
+
+interface ModerationCardProps {
+  character: PendingCharacter;
+  onApprove: (id: number) => void;
+  onReject: (id: number) => void;
+  isApproving: boolean;
+}
+
+export const ModerationCard = memo(function ModerationCard({
+  character,
+  onApprove,
+  onReject,
+  isApproving,
+}: ModerationCardProps) {
+  return (
+    <div className="bg-dark-800 border border-dark-700 rounded-xl p-4 flex flex-col gap-3">
+      <div className="flex items-start gap-4">
+        <div className="flex-shrink-0">
+          <MiniPreview
+            skinColor={character.skinColor}
+            hairColor={character.hairColor}
+            eyeColor={character.eyeColor}
+            faceShape={character.faceShape}
+            hairStyle={character.hairStyle}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <p className="text-cream-100 font-semibold truncate">
+            {character.name}
+          </p>
+
+          <div className="flex items-center gap-1.5 mt-1">
+            {CLASS_ICONS[character.className] && (
+              <span className="w-4 h-4 text-gold-400 flex-shrink-0" aria-hidden="true">
+                {CLASS_ICONS[character.className]}
+              </span>
+            )}
+            <span className="text-sm text-cream-400">{character.className}</span>
+          </div>
+
+          <p className="text-xs text-cream-500 mt-2 truncate">
+            par <span className="text-cream-300">{character.ownerPseudo}</span>
+          </p>
+
+          <time
+            dateTime={character.submittedAt}
+            className="text-xs text-cream-600 mt-1 block"
+          >
+            {formatRelativeDate(character.submittedAt)}
+          </time>
+        </div>
+      </div>
+
+      <div className="flex gap-2 mt-auto">
+        <Button
+          variant="success"
+          size="sm"
+          onClick={() => onApprove(character.id)}
+          isLoading={isApproving}
+          aria-label={`Approuver ${character.name}`}
+          className="flex-1"
+        >
+          Approuver
+        </Button>
+        <Button
+          variant="danger"
+          size="sm"
+          onClick={() => onReject(character.id)}
+          disabled={isApproving}
+          aria-label={`Rejeter ${character.name}`}
+          className="flex-1"
+        >
+          Rejeter
+        </Button>
+      </div>
+    </div>
+  );
+});

--- a/src/frontend/src/components/moderation/ModerationStats.tsx
+++ b/src/frontend/src/components/moderation/ModerationStats.tsx
@@ -1,0 +1,26 @@
+interface ModerationStatsProps {
+  pendingCount: number;
+  isLoading: boolean;
+}
+
+export function ModerationStats({ pendingCount, isLoading }: ModerationStatsProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+      <div className="bg-dark-800 border border-dark-700 rounded-xl p-4 flex items-center gap-4">
+        <div className="w-10 h-10 rounded-lg bg-gold-500/10 flex items-center justify-center flex-shrink-0">
+          <svg className="w-5 h-5 text-gold-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </div>
+        <div>
+          {isLoading ? (
+            <div className="h-7 w-10 bg-dark-700 rounded animate-pulse" />
+          ) : (
+            <p className="text-2xl font-bold text-cream-100">{pendingCount}</p>
+          )}
+          <p className="text-sm text-cream-400">En attente</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/moderation/RejectReasonModal.tsx
+++ b/src/frontend/src/components/moderation/RejectReasonModal.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from '../ui';
+
+interface RejectReasonModalProps {
+  isOpen: boolean;
+  characterName: string;
+  onConfirm: (reason: string) => void;
+  onClose: () => void;
+  isSubmitting: boolean;
+}
+
+const MIN_LENGTH = 10;
+const MAX_LENGTH = 500;
+
+export function RejectReasonModal({
+  isOpen,
+  characterName,
+  onConfirm,
+  onClose,
+  isSubmitting,
+}: RejectReasonModalProps) {
+  const [reason, setReason] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    const trimmed = reason.trim();
+
+    if (!trimmed) {
+      setValidationError('Le motif de rejet est obligatoire.');
+      return;
+    }
+
+    if (trimmed.length < MIN_LENGTH) {
+      setValidationError(`Le motif doit contenir au moins ${MIN_LENGTH} caractères.`);
+      return;
+    }
+
+    setValidationError(null);
+    onConfirm(trimmed);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="md">
+      <ModalHeader onClose={onClose}>
+        Rejeter {characterName}
+      </ModalHeader>
+      <ModalBody>
+        <label htmlFor="reject-reason" className="block text-sm font-medium text-cream-300 mb-2">
+          Motif du rejet
+        </label>
+        <textarea
+          id="reject-reason"
+          autoFocus
+          value={reason}
+          onChange={(e) => {
+            setReason(e.target.value);
+            if (validationError) setValidationError(null);
+          }}
+          maxLength={MAX_LENGTH}
+          rows={4}
+          placeholder="Expliquez pourquoi ce personnage est rejeté…"
+          className="w-full px-3 py-2 bg-dark-900 border border-dark-600 rounded-lg text-cream-200 placeholder-cream-600 focus:outline-none focus:ring-2 focus:ring-gold-500 focus:border-transparent resize-vertical"
+          aria-describedby={validationError ? 'reject-reason-error' : undefined}
+          aria-invalid={validationError ? 'true' : undefined}
+        />
+        <div className="flex justify-between items-center mt-1">
+          {validationError ? (
+            <p id="reject-reason-error" className="text-sm text-error-500" role="alert">
+              {validationError}
+            </p>
+          ) : (
+            <span />
+          )}
+          <span className="text-xs text-cream-600">
+            {reason.length}/{MAX_LENGTH}
+          </span>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="outline" size="sm" onClick={onClose} disabled={isSubmitting}>
+          Annuler
+        </Button>
+        <Button variant="danger" size="sm" onClick={handleSubmit} isLoading={isSubmitting}>
+          Confirmer le rejet
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+}

--- a/src/frontend/src/components/moderation/index.ts
+++ b/src/frontend/src/components/moderation/index.ts
@@ -1,0 +1,3 @@
+export { ModerationCard } from './ModerationCard';
+export { RejectReasonModal } from './RejectReasonModal';
+export { ModerationStats } from './ModerationStats';

--- a/src/frontend/src/components/ui/Button/Button.tsx
+++ b/src/frontend/src/components/ui/Button/Button.tsx
@@ -1,6 +1,6 @@
 import { type ButtonHTMLAttributes, forwardRef } from 'react';
 
-type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
+type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger' | 'success';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -21,6 +21,8 @@ const variantStyles: Record<ButtonVariant, string> = {
     'bg-transparent text-cream-200 hover:bg-dark-600 active:bg-dark-500',
   danger:
     'bg-error-500 text-white hover:bg-error-600 active:bg-error-600',
+  success:
+    'bg-success-500 text-white hover:bg-success-600 active:bg-success-600',
 };
 
 const sizeStyles: Record<ButtonSize, string> = {

--- a/src/frontend/src/pages/ModerationPage.test.tsx
+++ b/src/frontend/src/pages/ModerationPage.test.tsx
@@ -1,0 +1,280 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import ModerationPage from './ModerationPage';
+import * as moderationService from '../services/moderationService';
+import type { PendingCharacter, PagedResponse } from '../types';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: true,
+    user: { id: 1, email: 'employee@example.com', pseudo: 'Moderator', role: 'Employee' },
+    token: 'fake-employee-token',
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../services/moderationService', () => ({
+  getPendingCharacters: vi.fn(),
+  approveCharacter: vi.fn(),
+  rejectCharacter: vi.fn(),
+}));
+
+const mockPendingCharacters = (): PendingCharacter[] => [
+  {
+    id: 1,
+    name: 'Arthas',
+    className: 'Guerrier',
+    gender: 'Male',
+    skinColor: '#E8BEAC',
+    eyeColor: '#4A90D9',
+    hairColor: '#2C1810',
+    hairStyle: 'court',
+    eyeShape: 'amande',
+    noseShape: 'droit',
+    mouthShape: 'fine',
+    faceShape: 'ovale',
+    ownerPseudo: 'TestUser',
+    submittedAt: new Date(Date.now() - 86400000 * 2).toISOString(),
+  },
+  {
+    id: 2,
+    name: 'Jaina',
+    className: 'Mage',
+    gender: 'Female',
+    skinColor: '#FFDFC4',
+    eyeColor: '#2196F3',
+    hairColor: '#DAA520',
+    hairStyle: 'long',
+    eyeShape: 'amande',
+    noseShape: 'droit',
+    mouthShape: 'charnue',
+    faceShape: 'ovale',
+    ownerPseudo: 'AnotherUser',
+    submittedAt: new Date(Date.now() - 86400000 * 5).toISOString(),
+  },
+];
+
+const pagedResponse = (
+  items: PendingCharacter[] = mockPendingCharacters(),
+  totalCount?: number,
+  totalPages?: number
+): PagedResponse<PendingCharacter> => ({
+  items,
+  page: 1,
+  pageSize: 12,
+  totalCount: totalCount ?? items.length,
+  totalPages: totalPages ?? 1,
+});
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/moderation']}>
+      <Routes>
+        <Route path="/moderation" element={<ModerationPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+const setupWithCharacters = async (data?: PagedResponse<PendingCharacter>) => {
+  vi.mocked(moderationService.getPendingCharacters).mockResolvedValue(
+    data ?? pagedResponse()
+  );
+  renderPage();
+  await screen.findByText('Arthas');
+};
+
+describe('ModerationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loading state', () => {
+    it('should show loading spinner initially', () => {
+      vi.mocked(moderationService.getPendingCharacters).mockReturnValue(
+        new Promise(() => {})
+      );
+      renderPage();
+
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
+  });
+
+  describe('with pending characters', () => {
+    it('should display character names', async () => {
+      await setupWithCharacters();
+
+      expect(screen.getByText('Arthas')).toBeInTheDocument();
+      expect(screen.getByText('Jaina')).toBeInTheDocument();
+    });
+
+    it('should display pending count in stats', async () => {
+      await setupWithCharacters();
+
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('En attente')).toBeInTheDocument();
+    });
+
+    it('should render a semantic list', async () => {
+      await setupWithCharacters();
+
+      const list = screen.getByRole('list', { name: /personnages en attente/i });
+      const items = within(list).getAllByRole('listitem');
+      expect(items).toHaveLength(2);
+    });
+  });
+
+  describe('empty state', () => {
+    it('should show empty message when no pending characters', async () => {
+      vi.mocked(moderationService.getPendingCharacters).mockResolvedValue(
+        pagedResponse([], 0, 0)
+      );
+      renderPage();
+
+      expect(
+        await screen.findByText(/aucun personnage en attente de modération/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('should show error when fetch fails', async () => {
+      vi.mocked(moderationService.getPendingCharacters).mockRejectedValue(
+        new Error('fail')
+      );
+      renderPage();
+
+      expect(
+        await screen.findByText(/impossible de charger/i)
+      ).toBeInTheDocument();
+    });
+
+    it('should reload data when clicking retry', async () => {
+      const user = userEvent.setup();
+      vi.mocked(moderationService.getPendingCharacters)
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce(pagedResponse());
+
+      renderPage();
+      const retryButton = await screen.findByText(/réessayer/i);
+      await user.click(retryButton);
+
+      await waitFor(() => {
+        expect(moderationService.getPendingCharacters).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('approve action', () => {
+    it('should call approveCharacter and remove card', async () => {
+      const user = userEvent.setup();
+      vi.mocked(moderationService.approveCharacter).mockResolvedValue({
+        id: 1, name: 'Arthas', classId: 1, className: 'Guerrier', gender: 'Male',
+        status: 'Approved', skinColor: '', eyeColor: '', hairColor: '', hairStyle: '',
+        eyeShape: '', noseShape: '', mouthShape: '', faceShape: '', isShared: false,
+        isOwner: false, createdAt: '', updatedAt: '',
+      });
+      await setupWithCharacters();
+
+      const approveButton = screen.getByRole('button', { name: /approuver arthas/i });
+      await user.click(approveButton);
+
+      await waitFor(() => {
+        expect(moderationService.approveCharacter).toHaveBeenCalledWith(1, 'fake-employee-token');
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Arthas')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Jaina')).toBeInTheDocument();
+    });
+  });
+
+  describe('reject action', () => {
+    it('should open reject modal when clicking reject', async () => {
+      const user = userEvent.setup();
+      await setupWithCharacters();
+
+      const rejectButton = screen.getByRole('button', { name: /rejeter arthas/i });
+      await user.click(rejectButton);
+
+      expect(screen.getByText(/rejeter arthas/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/motif du rejet/i)).toBeInTheDocument();
+    });
+
+    it('should show validation error when reason is too short', async () => {
+      const user = userEvent.setup();
+      await setupWithCharacters();
+
+      await user.click(screen.getByRole('button', { name: /rejeter arthas/i }));
+      const textarea = screen.getByLabelText(/motif du rejet/i);
+      await user.type(textarea, 'Court');
+      await user.click(screen.getByRole('button', { name: /confirmer le rejet/i }));
+
+      expect(
+        await screen.findByText(/au moins 10 caractères/i)
+      ).toBeInTheDocument();
+      expect(moderationService.rejectCharacter).not.toHaveBeenCalled();
+    });
+
+    it('should call rejectCharacter and remove card on valid submission', async () => {
+      const user = userEvent.setup();
+      vi.mocked(moderationService.rejectCharacter).mockResolvedValue({
+        id: 1, name: 'Arthas', classId: 1, className: 'Guerrier', gender: 'Male',
+        status: 'Rejected', skinColor: '', eyeColor: '', hairColor: '', hairStyle: '',
+        eyeShape: '', noseShape: '', mouthShape: '', faceShape: '', isShared: false,
+        isOwner: false, createdAt: '', updatedAt: '',
+      });
+      await setupWithCharacters();
+
+      await user.click(screen.getByRole('button', { name: /rejeter arthas/i }));
+      const textarea = screen.getByLabelText(/motif du rejet/i);
+      await user.type(textarea, 'Contenu inapproprié pour le jeu');
+      await user.click(screen.getByRole('button', { name: /confirmer le rejet/i }));
+
+      await waitFor(() => {
+        expect(moderationService.rejectCharacter).toHaveBeenCalledWith(
+          1,
+          'Contenu inapproprié pour le jeu',
+          'fake-employee-token'
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Arthas')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('Jaina')).toBeInTheDocument();
+    });
+  });
+
+  describe('pagination', () => {
+    it('should show pagination when multiple pages', async () => {
+      await setupWithCharacters(pagedResponse(mockPendingCharacters(), 24, 2));
+
+      expect(screen.getByLabelText('Pagination')).toBeInTheDocument();
+    });
+
+    it('should not show pagination for single page', async () => {
+      await setupWithCharacters(pagedResponse(mockPendingCharacters(), 2, 1));
+
+      expect(screen.queryByLabelText('Pagination')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility (RGAA/WCAG)', () => {
+    it('should have no accessibility violations', async () => {
+      vi.mocked(moderationService.getPendingCharacters).mockResolvedValue(
+        pagedResponse()
+      );
+      const { container } = renderPage();
+      await screen.findByText('Arthas');
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+});

--- a/src/frontend/src/pages/ModerationPage.tsx
+++ b/src/frontend/src/pages/ModerationPage.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { getPendingCharacters, approveCharacter, rejectCharacter } from '../services/moderationService';
+import type { PendingCharacter, PagedResponse } from '../types';
+import { Header, Footer } from '../components/layout';
+import { ModerationCard, RejectReasonModal, ModerationStats } from '../components/moderation';
+import { Alert, Pagination } from '../components/ui';
+
+export default function ModerationPage() {
+  const { token } = useAuth();
+
+  const [data, setData] = useState<PagedResponse<PendingCharacter> | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+
+  const [approvingId, setApprovingId] = useState<number | null>(null);
+  const [rejectModal, setRejectModal] = useState<{ isOpen: boolean; character: PendingCharacter | null }>({
+    isOpen: false,
+    character: null,
+  });
+  const [isRejecting, setIsRejecting] = useState(false);
+
+  const requestIdRef = useRef(0);
+
+  const characters = data?.items ?? [];
+  const totalPages = data?.totalPages ?? 0;
+  const totalCount = data?.totalCount ?? 0;
+
+  const fetchPending = useCallback(async () => {
+    if (!token) return;
+    const currentRequestId = ++requestIdRef.current;
+    setError(null);
+    setIsLoading(true);
+    try {
+      const result = await getPendingCharacters(page, token);
+      if (currentRequestId !== requestIdRef.current) return;
+      setData(result);
+    } catch {
+      if (currentRequestId !== requestIdRef.current) return;
+      setError('Impossible de charger les personnages en attente.');
+    } finally {
+      if (currentRequestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [page, token]);
+
+  useEffect(() => {
+    fetchPending();
+  }, [fetchPending]);
+
+  const handleApprove = async (id: number) => {
+    if (!token) return;
+    setApprovingId(id);
+    setError(null);
+    try {
+      await approveCharacter(id, token);
+      setData((prev) => {
+        if (!prev) return prev;
+        const filtered = prev.items.filter((c) => c.id !== id);
+        return { ...prev, items: filtered, totalCount: prev.totalCount - 1 };
+      });
+    } catch {
+      setError("Erreur lors de l'approbation du personnage.");
+    } finally {
+      setApprovingId(null);
+    }
+  };
+
+  const handleRejectOpen = (id: number) => {
+    const character = characters.find((c) => c.id === id) ?? null;
+    setRejectModal({ isOpen: true, character });
+  };
+
+  const handleRejectClose = () => {
+    setRejectModal({ isOpen: false, character: null });
+  };
+
+  const handleRejectConfirm = async (reason: string) => {
+    if (!token || !rejectModal.character) return;
+    setIsRejecting(true);
+    setError(null);
+    try {
+      await rejectCharacter(rejectModal.character.id, reason, token);
+      setData((prev) => {
+        if (!prev) return prev;
+        const filtered = prev.items.filter((c) => c.id !== rejectModal.character!.id);
+        return { ...prev, items: filtered, totalCount: prev.totalCount - 1 };
+      });
+      handleRejectClose();
+    } catch {
+      setError('Erreur lors du rejet du personnage.');
+    } finally {
+      setIsRejecting(false);
+    }
+  };
+
+  // Si la page courante se vide après action et qu'on n'est pas en page 1, revenir en arrière
+  useEffect(() => {
+    if (!isLoading && data && data.items.length === 0 && page > 1) {
+      setPage(page - 1);
+    }
+  }, [data, isLoading, page]);
+
+  return (
+    <div className="min-h-screen bg-dark-950 flex flex-col">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-gold-500 focus:text-dark-950 focus:rounded-lg focus:font-medium"
+      >
+        Aller au contenu principal
+      </a>
+
+      <Header />
+
+      <main id="main-content" className="flex-1">
+        <div className="max-w-6xl mx-auto px-4 py-8 sm:py-12">
+          <div className="mb-8">
+            <h1 className="text-3xl sm:text-4xl font-display text-gold-300">
+              Modération
+            </h1>
+            <p className="mt-2 text-cream-400">
+              Gérez les personnages en attente de validation.
+            </p>
+          </div>
+
+          <ModerationStats pendingCount={totalCount} isLoading={isLoading} />
+
+          {error && (
+            <Alert variant="error" className="mb-6">
+              <div className="flex items-center justify-between">
+                <span>{error}</span>
+                <button
+                  type="button"
+                  onClick={fetchPending}
+                  className="ml-4 text-sm font-medium underline hover:no-underline"
+                >
+                  Réessayer
+                </button>
+              </div>
+            </Alert>
+          )}
+
+          {isLoading && (
+            <div className="flex justify-center py-20" role="status" aria-label="Chargement">
+              <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-gold-500" />
+            </div>
+          )}
+
+          {!isLoading && !error && characters.length === 0 && (
+            <div className="text-center py-20">
+              <svg className="w-16 h-16 mx-auto text-cream-700 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <p className="text-cream-500 text-lg">Aucun personnage en attente de modération.</p>
+            </div>
+          )}
+
+          {!isLoading && !error && characters.length > 0 && (
+            <ul
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 list-none p-0 m-0"
+              aria-label="Personnages en attente de modération"
+            >
+              {characters.map((character) => (
+                <li key={character.id}>
+                  <ModerationCard
+                    character={character}
+                    onApprove={handleApprove}
+                    onReject={handleRejectOpen}
+                    isApproving={approvingId === character.id}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {totalPages > 1 && (
+            <div className="mt-8 flex justify-center">
+              <Pagination
+                currentPage={page}
+                totalPages={totalPages}
+                onChange={setPage}
+              />
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Footer />
+
+      <RejectReasonModal
+        key={rejectModal.character?.id}
+        isOpen={rejectModal.isOpen}
+        characterName={rejectModal.character?.name ?? ''}
+        onConfirm={handleRejectConfirm}
+        onClose={handleRejectClose}
+        isSubmitting={isRejecting}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/pages/index.ts
+++ b/src/frontend/src/pages/index.ts
@@ -10,3 +10,4 @@ export { default as EditCharacterPage } from './EditCharacterPage';
 export { default as CharacterDetailPage } from './CharacterDetailPage';
 export { default as GalleryPage } from './GalleryPage';
 export { default as LegalPage } from './LegalPage';
+export { default as ModerationPage } from './ModerationPage';

--- a/src/frontend/src/services/moderationService.ts
+++ b/src/frontend/src/services/moderationService.ts
@@ -1,0 +1,39 @@
+import { apiClient } from './api';
+import type {
+  CharacterResponse,
+  PendingCharacter,
+  PagedResponse,
+} from '../types';
+
+export const getPendingCharacters = (
+  page: number,
+  token: string
+): Promise<PagedResponse<PendingCharacter>> => {
+  const params = new URLSearchParams();
+  params.set('page', String(page));
+  params.set('pageSize', '12');
+  return apiClient.getAuthenticated<PagedResponse<PendingCharacter>>(
+    `/moderation/characters?${params.toString()}`,
+    token
+  );
+};
+
+export const approveCharacter = (
+  id: number,
+  token: string
+): Promise<CharacterResponse> =>
+  apiClient.patchAuthenticated<CharacterResponse>(
+    `/moderation/characters/${id}/approve`,
+    token
+  );
+
+export const rejectCharacter = (
+  id: number,
+  reason: string,
+  token: string
+): Promise<CharacterResponse> =>
+  apiClient.patchAuthenticatedWithBody<{ reason: string }, CharacterResponse>(
+    `/moderation/characters/${id}/reject`,
+    { reason },
+    token
+  );

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './common';
 export * from './character-requests';
 export * from './character-responses';
 export * from './gallery';
+export * from './moderation';

--- a/src/frontend/src/types/moderation.ts
+++ b/src/frontend/src/types/moderation.ts
@@ -1,0 +1,16 @@
+export interface PendingCharacter {
+  id: number;
+  name: string;
+  className: string;
+  gender: string;
+  skinColor: string;
+  eyeColor: string;
+  hairColor: string;
+  hairStyle: string;
+  eyeShape: string;
+  noseShape: string;
+  mouthShape: string;
+  faceShape: string;
+  ownerPseudo: string;
+  submittedAt: string;
+}


### PR DESCRIPTION
## Summary
- Create `/moderation` page with pending characters grid, approve/reject flows, pagination and responsive layout
- Add `ModerationCard`, `RejectReasonModal`, `ModerationStats` components with full accessibility (aria-labels, semantic HTML, axe clean)
- Add `moderationService` (list, approve, reject) and `PendingCharacter` type
- Add `success` variant to `Button` component aligned on design system tokens (`success-500/600`)
- Add staff menu separators in `Header` (desktop dropdown + mobile menu)
- Refactor `ApiClient` to eliminate duplicated fetch/error handling (281 → 120 lines)
- 14 unit tests covering loading, display, empty, error, retry, approve, reject modal + validation, pagination, a11y

## Test plan
- [x] `npm run build` — 0 errors
- [x] `npm run test` — 459 tests pass (14 new)
- [x] `npx tsc --noEmit` — 0 errors
- [x] E2E Playwright: login Employee → dropdown separators → moderation page → reject modal validation → approve flow → DB verified
- [x] Responsive: 1 col mobile / 2 col tablet / 3 col desktop
- [x] Accessibility: axe clean, aria-labels, keyboard navigation

Closes #69