### PR TITLE
refactor(backend): migrate domain entities to Rich Domain Model

### DIFF
--- a/src/backend/src/FantasyRealm.Application/Mapping/CommentMapper.cs
+++ b/src/backend/src/FantasyRealm.Application/Mapping/CommentMapper.cs
@@ -1,6 +1,5 @@
 using FantasyRealm.Application.DTOs;
 using FantasyRealm.Domain.Entities;
-using FantasyRealm.Domain.Enums;
 
 namespace FantasyRealm.Application.Mapping
 {
@@ -56,15 +55,7 @@ namespace FantasyRealm.Application.Mapping
         /// <returns>A new <see cref="Comment"/> entity ready to be persisted.</returns>
         public static Comment ToEntity(CreateCommentRequest request, int characterId, int authorId)
         {
-            return new Comment
-            {
-                Rating = request.Rating,
-                Text = request.Text,
-                Status = CommentStatus.Pending,
-                CommentedAt = DateTime.UtcNow,
-                CharacterId = characterId,
-                AuthorId = authorId
-            };
+            return Comment.Create(request.Rating, request.Text, characterId, authorId);
         }
     }
 }

--- a/src/backend/src/FantasyRealm.Domain/Entities/Character.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/Character.cs
@@ -1,4 +1,5 @@
 using FantasyRealm.Domain.Enums;
+using FantasyRealm.Domain.Exceptions;
 
 namespace FantasyRealm.Domain.Entities
 {
@@ -9,39 +10,39 @@ namespace FantasyRealm.Domain.Entities
     {
         public int Id { get; set; }
 
-        public string Name { get; set; } = string.Empty;
+        public string Name { get; internal set; } = string.Empty;
 
-        public int ClassId { get; set; }
+        public int ClassId { get; internal set; }
 
-        public Gender Gender { get; set; }
+        public Gender Gender { get; internal set; }
 
-        public CharacterStatus Status { get; set; }
+        public CharacterStatus Status { get; internal set; }
 
-        public string SkinColor { get; set; } = string.Empty;
+        public string SkinColor { get; internal set; } = string.Empty;
 
-        public string EyeColor { get; set; } = string.Empty;
+        public string EyeColor { get; internal set; } = string.Empty;
 
-        public string HairColor { get; set; } = string.Empty;
+        public string HairColor { get; internal set; } = string.Empty;
 
-        public string HairStyle { get; set; } = string.Empty;
+        public string HairStyle { get; internal set; } = string.Empty;
 
-        public string EyeShape { get; set; } = string.Empty;
+        public string EyeShape { get; internal set; } = string.Empty;
 
-        public string NoseShape { get; set; } = string.Empty;
+        public string NoseShape { get; internal set; } = string.Empty;
 
-        public string MouthShape { get; set; } = string.Empty;
+        public string MouthShape { get; internal set; } = string.Empty;
 
-        public string FaceShape { get; set; } = string.Empty;
+        public string FaceShape { get; internal set; } = string.Empty;
 
-        public byte[]? Image { get; set; }
+        public byte[]? Image { get; internal set; }
 
-        public bool IsShared { get; set; }
+        public bool IsShared { get; internal set; }
 
-        public DateTime CreatedAt { get; set; }
+        public DateTime CreatedAt { get; internal set; }
 
-        public DateTime UpdatedAt { get; set; }
+        public DateTime UpdatedAt { get; internal set; }
 
-        public int UserId { get; set; }
+        public int UserId { get; internal set; }
 
         public User User { get; set; } = null!;
 
@@ -50,5 +51,167 @@ namespace FantasyRealm.Domain.Entities
         public ICollection<CharacterArticle> CharacterArticles { get; set; } = [];
 
         public ICollection<Comment> Comments { get; set; } = [];
+
+        /// <summary>
+        /// Creates a new character in draft status.
+        /// </summary>
+        public static Character Create(
+            string name,
+            int classId,
+            Gender gender,
+            string skinColor,
+            string eyeColor,
+            string hairColor,
+            string hairStyle,
+            string eyeShape,
+            string noseShape,
+            string mouthShape,
+            string faceShape,
+            int userId)
+        {
+            return new Character
+            {
+                Name = name,
+                ClassId = classId,
+                Gender = gender,
+                Status = CharacterStatus.Draft,
+                SkinColor = skinColor,
+                EyeColor = eyeColor,
+                HairColor = hairColor,
+                HairStyle = hairStyle,
+                EyeShape = eyeShape,
+                NoseShape = noseShape,
+                MouthShape = mouthShape,
+                FaceShape = faceShape,
+                IsShared = false,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                UserId = userId
+            };
+        }
+
+        /// <summary>
+        /// Creates a duplicate of an existing character with a new name in draft status.
+        /// </summary>
+        /// <param name="source">The character to duplicate.</param>
+        /// <param name="newName">The name for the duplicate.</param>
+        /// <param name="userId">The owner of the duplicate.</param>
+        public static Character Duplicate(Character source, string newName, int userId)
+        {
+            return new Character
+            {
+                Name = newName,
+                ClassId = source.ClassId,
+                Gender = source.Gender,
+                Status = CharacterStatus.Draft,
+                SkinColor = source.SkinColor,
+                EyeColor = source.EyeColor,
+                HairColor = source.HairColor,
+                HairStyle = source.HairStyle,
+                EyeShape = source.EyeShape,
+                NoseShape = source.NoseShape,
+                MouthShape = source.MouthShape,
+                FaceShape = source.FaceShape,
+                IsShared = false,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                UserId = userId
+            };
+        }
+
+        /// <summary>
+        /// Submits the character for moderation review.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the character is not in a submittable state.</exception>
+        public void SubmitForReview()
+        {
+            if (Status is not (CharacterStatus.Draft or CharacterStatus.Rejected))
+                throw new DomainException("Seuls les personnages en brouillon ou rejetés peuvent être soumis.");
+
+            Status = CharacterStatus.Pending;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Approves the character after moderation review.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the character is not pending review.</exception>
+        public void Approve()
+        {
+            if (Status is not CharacterStatus.Pending)
+                throw new DomainException("Seuls les personnages en attente peuvent être approuvés.");
+
+            Status = CharacterStatus.Approved;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Rejects the character after moderation review.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the character is not pending review.</exception>
+        public void Reject()
+        {
+            if (Status is not CharacterStatus.Pending)
+                throw new DomainException("Seuls les personnages en attente peuvent être rejetés.");
+
+            Status = CharacterStatus.Rejected;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Toggles the shared visibility of an approved character.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the character is not approved.</exception>
+        public void ToggleShare()
+        {
+            if (Status != CharacterStatus.Approved)
+                throw new DomainException("Seuls les personnages approuvés peuvent être partagés.");
+
+            IsShared = !IsShared;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Updates the character appearance and metadata.
+        /// If the character is approved and the name changes, it is automatically re-submitted for review.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the character is not in an editable state.</exception>
+        public void UpdateAppearance(
+            string name,
+            int classId,
+            Gender gender,
+            string skinColor,
+            string eyeColor,
+            string hairColor,
+            string hairStyle,
+            string eyeShape,
+            string noseShape,
+            string mouthShape,
+            string faceShape)
+        {
+            if (Status is not (CharacterStatus.Draft or CharacterStatus.Rejected or CharacterStatus.Approved))
+                throw new DomainException("Seuls les personnages en brouillon, rejetés ou approuvés peuvent être modifiés.");
+
+            var nameChanged = !string.Equals(Name, name, StringComparison.Ordinal);
+
+            Name = name;
+            ClassId = classId;
+            Gender = gender;
+            SkinColor = skinColor;
+            EyeColor = eyeColor;
+            HairColor = hairColor;
+            HairStyle = hairStyle;
+            EyeShape = eyeShape;
+            NoseShape = noseShape;
+            MouthShape = mouthShape;
+            FaceShape = faceShape;
+            UpdatedAt = DateTime.UtcNow;
+
+            if (Status == CharacterStatus.Approved && nameChanged)
+            {
+                Status = CharacterStatus.Pending;
+                IsShared = false;
+            }
+        }
     }
 }

--- a/src/backend/src/FantasyRealm.Domain/Entities/Comment.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/Comment.cs
@@ -1,4 +1,5 @@
 using FantasyRealm.Domain.Enums;
+using FantasyRealm.Domain.Exceptions;
 
 namespace FantasyRealm.Domain.Entities
 {
@@ -9,28 +10,91 @@ namespace FantasyRealm.Domain.Entities
     {
         public int Id { get; set; }
 
-        public int Rating { get; set; }
+        public int Rating { get; internal set; }
 
-        public string Text { get; set; } = string.Empty;
+        public string Text { get; internal set; } = string.Empty;
 
-        public CommentStatus Status { get; set; }
+        public CommentStatus Status { get; internal set; }
 
-        public DateTime CommentedAt { get; set; }
+        public DateTime CommentedAt { get; internal set; }
 
-        public int CharacterId { get; set; }
+        public int CharacterId { get; internal set; }
 
         public Character Character { get; set; } = null!;
 
-        public string? RejectionReason { get; set; }
+        public string? RejectionReason { get; internal set; }
 
-        public DateTime? ReviewedAt { get; set; }
+        public DateTime? ReviewedAt { get; internal set; }
 
-        public int AuthorId { get; set; }
+        public int AuthorId { get; internal set; }
 
         public User Author { get; set; } = null!;
 
-        public int? ReviewedById { get; set; }
+        public int? ReviewedById { get; internal set; }
 
         public User? ReviewedBy { get; set; }
+
+        /// <summary>
+        /// Creates a new comment in pending status.
+        /// </summary>
+        /// <param name="rating">The rating value.</param>
+        /// <param name="text">The comment text.</param>
+        /// <param name="characterId">The target character identifier.</param>
+        /// <param name="authorId">The author user identifier.</param>
+        public static Comment Create(int rating, string text, int characterId, int authorId)
+        {
+            return new Comment
+            {
+                Rating = rating,
+                Text = text,
+                Status = CommentStatus.Pending,
+                CommentedAt = DateTime.UtcNow,
+                CharacterId = characterId,
+                AuthorId = authorId
+            };
+        }
+
+        /// <summary>
+        /// Approves the comment after moderation review.
+        /// </summary>
+        /// <param name="reviewerId">The identifier of the moderator who approved the comment.</param>
+        /// <exception cref="DomainException">Thrown when the comment is not pending review.</exception>
+        public void Approve(int reviewerId)
+        {
+            if (Status is not CommentStatus.Pending)
+                throw new DomainException("Seuls les commentaires en attente peuvent être approuvés.");
+
+            Status = CommentStatus.Approved;
+            ReviewedAt = DateTime.UtcNow;
+            ReviewedById = reviewerId;
+        }
+
+        /// <summary>
+        /// Rejects the comment after moderation review with a mandatory reason.
+        /// </summary>
+        /// <param name="reason">The rejection reason (10-500 characters).</param>
+        /// <param name="reviewerId">The identifier of the moderator who rejected the comment.</param>
+        /// <exception cref="DomainException">Thrown when the comment is not pending or the reason is invalid.</exception>
+        public void Reject(string reason, int reviewerId)
+        {
+            if (Status is not CommentStatus.Pending)
+                throw new DomainException("Seuls les commentaires en attente peuvent être rejetés.");
+
+            if (string.IsNullOrWhiteSpace(reason))
+                throw new DomainException("Le motif de rejet est obligatoire.");
+
+            var trimmedReason = reason.Trim();
+
+            if (trimmedReason.Length < 10)
+                throw new DomainException("Le motif de rejet doit contenir au moins 10 caractères.");
+
+            if (trimmedReason.Length > 500)
+                throw new DomainException("Le motif de rejet ne peut pas dépasser 500 caractères.");
+
+            Status = CommentStatus.Rejected;
+            RejectionReason = trimmedReason;
+            ReviewedAt = DateTime.UtcNow;
+            ReviewedById = reviewerId;
+        }
     }
 }

--- a/src/backend/src/FantasyRealm.Domain/Entities/User.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/User.cs
@@ -1,3 +1,5 @@
+using FantasyRealm.Domain.Exceptions;
+
 namespace FantasyRealm.Domain.Entities
 {
     /// <summary>
@@ -7,26 +9,120 @@ namespace FantasyRealm.Domain.Entities
     {
         public int Id { get; set; }
 
-        public string Pseudo { get; set; } = string.Empty;
+        public string Pseudo { get; internal set; } = string.Empty;
 
-        public string Email { get; set; } = string.Empty;
+        public string Email { get; internal set; } = string.Empty;
 
-        public string PasswordHash { get; set; } = string.Empty;
+        public string PasswordHash { get; internal set; } = string.Empty;
 
-        public bool IsSuspended { get; set; }
+        public bool IsSuspended { get; internal set; }
 
-        public bool MustChangePassword { get; set; }
+        public bool MustChangePassword { get; internal set; }
 
-        public DateTime CreatedAt { get; set; }
+        public DateTime CreatedAt { get; internal set; }
 
-        public DateTime UpdatedAt { get; set; }
+        public DateTime UpdatedAt { get; internal set; }
 
-        public int RoleId { get; set; }
+        public int RoleId { get; internal set; }
 
-        public Role Role { get; set; } = null!;
+        public Role Role { get; internal set; } = null!;
 
         public ICollection<Character> Characters { get; set; } = [];
 
         public ICollection<Comment> Comments { get; set; } = [];
+
+        /// <summary>
+        /// Creates a new user account with the "User" role.
+        /// </summary>
+        /// <param name="email">The normalized email address.</param>
+        /// <param name="pseudo">The display name.</param>
+        /// <param name="passwordHash">The hashed password.</param>
+        /// <param name="role">The user role entity.</param>
+        public static User CreateUser(string email, string pseudo, string passwordHash, Role role)
+        {
+            return new User
+            {
+                Email = email,
+                Pseudo = pseudo,
+                PasswordHash = passwordHash,
+                RoleId = role.Id,
+                Role = role,
+                IsSuspended = false,
+                MustChangePassword = false,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        /// <summary>
+        /// Creates a new employee account.
+        /// </summary>
+        /// <param name="email">The normalized email address.</param>
+        /// <param name="pseudo">The display name derived from email.</param>
+        /// <param name="passwordHash">The hashed password.</param>
+        /// <param name="role">The employee role entity.</param>
+        public static User CreateEmployee(string email, string pseudo, string passwordHash, Role role)
+        {
+            return new User
+            {
+                Email = email,
+                Pseudo = pseudo,
+                PasswordHash = passwordHash,
+                RoleId = role.Id,
+                Role = role,
+                IsSuspended = false,
+                MustChangePassword = false,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+        }
+
+        /// <summary>
+        /// Suspends the user account.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the account is already suspended.</exception>
+        public void Suspend()
+        {
+            if (IsSuspended)
+                throw new DomainException("Ce compte est déjà suspendu.");
+
+            IsSuspended = true;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Reactivates a suspended user account.
+        /// </summary>
+        /// <exception cref="DomainException">Thrown when the account is not suspended.</exception>
+        public void Reactivate()
+        {
+            if (!IsSuspended)
+                throw new DomainException("Ce compte n'est pas suspendu.");
+
+            IsSuspended = false;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Sets a temporary password and marks the account for mandatory password change.
+        /// </summary>
+        /// <param name="passwordHash">The hashed temporary password.</param>
+        public void SetTemporaryPassword(string passwordHash)
+        {
+            PasswordHash = passwordHash;
+            MustChangePassword = true;
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Changes the password and clears the mandatory password change flag.
+        /// </summary>
+        /// <param name="passwordHash">The hashed new password.</param>
+        public void ChangePassword(string passwordHash)
+        {
+            PasswordHash = passwordHash;
+            MustChangePassword = false;
+            UpdatedAt = DateTime.UtcNow;
+        }
     }
 }

--- a/src/backend/src/FantasyRealm.Domain/Exceptions/DomainException.cs
+++ b/src/backend/src/FantasyRealm.Domain/Exceptions/DomainException.cs
@@ -1,0 +1,25 @@
+namespace FantasyRealm.Domain.Exceptions
+{
+    /// <summary>
+    /// Represents a violation of a domain invariant.
+    /// Thrown by entity methods when a business rule is broken.
+    /// </summary>
+    public class DomainException : Exception
+    {
+        /// <summary>
+        /// Gets the suggested HTTP status code for this domain error.
+        /// </summary>
+        public int StatusCode { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainException"/> class.
+        /// </summary>
+        /// <param name="message">The error message describing the invariant violation.</param>
+        /// <param name="statusCode">The suggested HTTP status code (default: 400).</param>
+        public DomainException(string message, int statusCode = 400)
+            : base(message)
+        {
+            StatusCode = statusCode;
+        }
+    }
+}

--- a/src/backend/src/FantasyRealm.Domain/FantasyRealm.Domain.csproj
+++ b/src/backend/src/FantasyRealm.Domain/FantasyRealm.Domain.csproj
@@ -10,4 +10,9 @@
     <PackageReference Include="MongoDB.Bson" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="FantasyRealm.Tests.Unit" />
+    <InternalsVisibleTo Include="FantasyRealm.Tests.Integration" />
+  </ItemGroup>
+
 </Project>

--- a/src/backend/src/FantasyRealm.Infrastructure/Repositories/UserRepository.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/Repositories/UserRepository.cs
@@ -71,7 +71,6 @@ namespace FantasyRealm.Infrastructure.Repositories
         /// <inheritdoc />
         public async Task<User> UpdateAsync(User user, CancellationToken cancellationToken = default)
         {
-            user.UpdatedAt = DateTime.UtcNow;
             context.Users.Update(user);
             await context.SaveChangesAsync(cancellationToken);
             return user;

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Entities/CharacterTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Entities/CharacterTests.cs
@@ -1,0 +1,202 @@
+using FantasyRealm.Domain.Entities;
+using FantasyRealm.Domain.Enums;
+using FantasyRealm.Domain.Exceptions;
+using Xunit;
+
+namespace FantasyRealm.Tests.Unit.Entities
+{
+    public class CharacterTests
+    {
+        [Fact]
+        public void SubmitForReview_WhenDraft_SetsStatusPending()
+        {
+            var character = new Character { Status = CharacterStatus.Draft };
+
+            character.SubmitForReview();
+
+            Assert.Equal(CharacterStatus.Pending, character.Status);
+        }
+
+        [Fact]
+        public void SubmitForReview_WhenRejected_SetsStatusPending()
+        {
+            var character = new Character { Status = CharacterStatus.Rejected };
+
+            character.SubmitForReview();
+
+            Assert.Equal(CharacterStatus.Pending, character.Status);
+        }
+
+        [Fact]
+        public void SubmitForReview_WhenApproved_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Approved };
+
+            var ex = Assert.Throws<DomainException>(() => character.SubmitForReview());
+            Assert.Contains("brouillon ou rejetés", ex.Message);
+        }
+
+        [Fact]
+        public void SubmitForReview_WhenPending_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Pending };
+
+            Assert.Throws<DomainException>(() => character.SubmitForReview());
+        }
+
+        [Fact]
+        public void Approve_WhenPending_SetsStatusApproved()
+        {
+            var character = new Character { Status = CharacterStatus.Pending };
+
+            character.Approve();
+
+            Assert.Equal(CharacterStatus.Approved, character.Status);
+        }
+
+        [Fact]
+        public void Approve_WhenNotPending_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Draft };
+
+            var ex = Assert.Throws<DomainException>(() => character.Approve());
+            Assert.Contains("en attente", ex.Message);
+        }
+
+        [Fact]
+        public void Reject_WhenPending_SetsStatusRejected()
+        {
+            var character = new Character { Status = CharacterStatus.Pending };
+
+            character.Reject();
+
+            Assert.Equal(CharacterStatus.Rejected, character.Status);
+        }
+
+        [Fact]
+        public void Reject_WhenNotPending_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Approved };
+
+            var ex = Assert.Throws<DomainException>(() => character.Reject());
+            Assert.Contains("en attente", ex.Message);
+        }
+
+        [Fact]
+        public void ToggleShare_WhenApproved_TogglesIsShared()
+        {
+            var character = new Character { Status = CharacterStatus.Approved, IsShared = false };
+
+            character.ToggleShare();
+            Assert.True(character.IsShared);
+
+            character.ToggleShare();
+            Assert.False(character.IsShared);
+        }
+
+        [Fact]
+        public void ToggleShare_WhenNotApproved_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Draft };
+
+            var ex = Assert.Throws<DomainException>(() => character.ToggleShare());
+            Assert.Contains("approuvés", ex.Message);
+        }
+
+        [Fact]
+        public void UpdateAppearance_WhenApprovedAndNameChanged_SetsStatusPending()
+        {
+            var character = new Character
+            {
+                Name = "OldName",
+                Status = CharacterStatus.Approved,
+                IsShared = true
+            };
+
+            character.UpdateAppearance(
+                "NewName", 1, Gender.Male,
+                "#fff", "#000", "#111", "short",
+                "round", "small", "wide", "oval");
+
+            Assert.Equal(CharacterStatus.Pending, character.Status);
+            Assert.False(character.IsShared);
+        }
+
+        [Fact]
+        public void UpdateAppearance_WhenApprovedAndNameUnchanged_KeepsStatusApproved()
+        {
+            var character = new Character
+            {
+                Name = "SameName",
+                Status = CharacterStatus.Approved,
+                IsShared = true
+            };
+
+            character.UpdateAppearance(
+                "SameName", 1, Gender.Male,
+                "#fff", "#000", "#111", "short",
+                "round", "small", "wide", "oval");
+
+            Assert.Equal(CharacterStatus.Approved, character.Status);
+            Assert.True(character.IsShared);
+        }
+
+        [Fact]
+        public void UpdateAppearance_WhenPending_ThrowsDomainException()
+        {
+            var character = new Character { Status = CharacterStatus.Pending };
+
+            var ex = Assert.Throws<DomainException>(() =>
+                character.UpdateAppearance(
+                    "Name", 1, Gender.Male,
+                    "#fff", "#000", "#111", "short",
+                    "round", "small", "wide", "oval"));
+
+            Assert.Contains("brouillon, rejetés ou approuvés", ex.Message);
+        }
+
+        [Fact]
+        public void Create_ReturnsCharacterInDraftStatus()
+        {
+            var character = Character.Create(
+                "Hero", 1, Gender.Male,
+                "#fff", "#000", "#111", "short",
+                "round", "small", "wide", "oval", 42);
+
+            Assert.Equal("Hero", character.Name);
+            Assert.Equal(CharacterStatus.Draft, character.Status);
+            Assert.Equal(42, character.UserId);
+            Assert.False(character.IsShared);
+        }
+
+        [Fact]
+        public void Duplicate_ReturnsNewCharacterInDraftStatus()
+        {
+            var source = new Character
+            {
+                Name = "Original",
+                ClassId = 2,
+                Gender = Gender.Female,
+                Status = CharacterStatus.Approved,
+                SkinColor = "#aaa",
+                EyeColor = "#bbb",
+                HairColor = "#ccc",
+                HairStyle = "long",
+                EyeShape = "almond",
+                NoseShape = "pointed",
+                MouthShape = "thin",
+                FaceShape = "round",
+                UserId = 10
+            };
+
+            var duplicate = Character.Duplicate(source, "Clone", 10);
+
+            Assert.Equal("Clone", duplicate.Name);
+            Assert.Equal(CharacterStatus.Draft, duplicate.Status);
+            Assert.Equal(source.ClassId, duplicate.ClassId);
+            Assert.Equal(source.Gender, duplicate.Gender);
+            Assert.Equal(source.SkinColor, duplicate.SkinColor);
+            Assert.False(duplicate.IsShared);
+        }
+    }
+}

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Entities/CommentTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Entities/CommentTests.cs
@@ -1,0 +1,97 @@
+using FantasyRealm.Domain.Entities;
+using FantasyRealm.Domain.Enums;
+using FantasyRealm.Domain.Exceptions;
+using Xunit;
+
+namespace FantasyRealm.Tests.Unit.Entities
+{
+    public class CommentTests
+    {
+        [Fact]
+        public void Approve_WhenPending_SetsStatusApproved()
+        {
+            var comment = new Comment { Status = CommentStatus.Pending };
+
+            comment.Approve(reviewerId: 5);
+
+            Assert.Equal(CommentStatus.Approved, comment.Status);
+            Assert.Equal(5, comment.ReviewedById);
+            Assert.NotNull(comment.ReviewedAt);
+        }
+
+        [Fact]
+        public void Approve_WhenNotPending_ThrowsDomainException()
+        {
+            var comment = new Comment { Status = CommentStatus.Approved };
+
+            var ex = Assert.Throws<DomainException>(() => comment.Approve(reviewerId: 5));
+            Assert.Contains("en attente", ex.Message);
+        }
+
+        [Fact]
+        public void Reject_WhenPending_SetsStatusRejected()
+        {
+            var comment = new Comment { Status = CommentStatus.Pending };
+
+            comment.Reject("Contenu inapproprié pour la plateforme", reviewerId: 5);
+
+            Assert.Equal(CommentStatus.Rejected, comment.Status);
+            Assert.Equal("Contenu inapproprié pour la plateforme", comment.RejectionReason);
+            Assert.Equal(5, comment.ReviewedById);
+            Assert.NotNull(comment.ReviewedAt);
+        }
+
+        [Fact]
+        public void Reject_WhenNotPending_ThrowsDomainException()
+        {
+            var comment = new Comment { Status = CommentStatus.Rejected };
+
+            var ex = Assert.Throws<DomainException>(() =>
+                comment.Reject("Raison valide de plus de dix chars", reviewerId: 5));
+            Assert.Contains("en attente", ex.Message);
+        }
+
+        [Fact]
+        public void Reject_WhenReasonTooShort_ThrowsDomainException()
+        {
+            var comment = new Comment { Status = CommentStatus.Pending };
+
+            var ex = Assert.Throws<DomainException>(() =>
+                comment.Reject("Court", reviewerId: 5));
+            Assert.Contains("au moins 10 caractères", ex.Message);
+        }
+
+        [Fact]
+        public void Reject_WhenReasonTooLong_ThrowsDomainException()
+        {
+            var comment = new Comment { Status = CommentStatus.Pending };
+            var longReason = new string('x', 501);
+
+            var ex = Assert.Throws<DomainException>(() =>
+                comment.Reject(longReason, reviewerId: 5));
+            Assert.Contains("500 caractères", ex.Message);
+        }
+
+        [Fact]
+        public void Reject_WhenReasonEmpty_ThrowsDomainException()
+        {
+            var comment = new Comment { Status = CommentStatus.Pending };
+
+            var ex = Assert.Throws<DomainException>(() =>
+                comment.Reject("", reviewerId: 5));
+            Assert.Contains("obligatoire", ex.Message);
+        }
+
+        [Fact]
+        public void Create_ReturnsCommentInPendingStatus()
+        {
+            var comment = Comment.Create(4, "Great character!", 10, 20);
+
+            Assert.Equal(4, comment.Rating);
+            Assert.Equal("Great character!", comment.Text);
+            Assert.Equal(CommentStatus.Pending, comment.Status);
+            Assert.Equal(10, comment.CharacterId);
+            Assert.Equal(20, comment.AuthorId);
+        }
+    }
+}

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Entities/UserTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Entities/UserTests.cs
@@ -1,0 +1,104 @@
+using FantasyRealm.Domain.Entities;
+using FantasyRealm.Domain.Exceptions;
+using Xunit;
+
+namespace FantasyRealm.Tests.Unit.Entities
+{
+    public class UserTests
+    {
+        private static Role CreateRole(int id = 1, string label = "User") =>
+            new() { Id = id, Label = label };
+
+        [Fact]
+        public void Suspend_WhenNotSuspended_SetsIsSuspendedTrue()
+        {
+            var user = new User { IsSuspended = false };
+
+            user.Suspend();
+
+            Assert.True(user.IsSuspended);
+        }
+
+        [Fact]
+        public void Suspend_WhenAlreadySuspended_ThrowsDomainException()
+        {
+            var user = new User { IsSuspended = true };
+
+            var ex = Assert.Throws<DomainException>(() => user.Suspend());
+            Assert.Equal("Ce compte est déjà suspendu.", ex.Message);
+        }
+
+        [Fact]
+        public void Reactivate_WhenSuspended_SetsIsSuspendedFalse()
+        {
+            var user = new User { IsSuspended = true };
+
+            user.Reactivate();
+
+            Assert.False(user.IsSuspended);
+        }
+
+        [Fact]
+        public void Reactivate_WhenNotSuspended_ThrowsDomainException()
+        {
+            var user = new User { IsSuspended = false };
+
+            var ex = Assert.Throws<DomainException>(() => user.Reactivate());
+            Assert.Equal("Ce compte n'est pas suspendu.", ex.Message);
+        }
+
+        [Fact]
+        public void SetTemporaryPassword_SetsHashAndMustChangePassword()
+        {
+            var user = new User { PasswordHash = "old-hash", MustChangePassword = false };
+
+            user.SetTemporaryPassword("new-temp-hash");
+
+            Assert.Equal("new-temp-hash", user.PasswordHash);
+            Assert.True(user.MustChangePassword);
+        }
+
+        [Fact]
+        public void ChangePassword_SetsHashAndClearsMustChangePassword()
+        {
+            var user = new User { PasswordHash = "old-hash", MustChangePassword = true };
+
+            user.ChangePassword("new-hash");
+
+            Assert.Equal("new-hash", user.PasswordHash);
+            Assert.False(user.MustChangePassword);
+        }
+
+        [Fact]
+        public void CreateUser_ReturnsCorrectlyInitializedUser()
+        {
+            var role = CreateRole(1, "User");
+
+            var user = User.CreateUser("test@example.com", "testpseudo", "hashed", role);
+
+            Assert.Equal("test@example.com", user.Email);
+            Assert.Equal("testpseudo", user.Pseudo);
+            Assert.Equal("hashed", user.PasswordHash);
+            Assert.Equal(1, user.RoleId);
+            Assert.Same(role, user.Role);
+            Assert.False(user.IsSuspended);
+            Assert.False(user.MustChangePassword);
+        }
+
+        [Fact]
+        public void CreateEmployee_ReturnsCorrectlyInitializedUser()
+        {
+            var role = CreateRole(2, "Employee");
+
+            var user = User.CreateEmployee("emp@example.com", "emppseudo", "hashed", role);
+
+            Assert.Equal("emp@example.com", user.Email);
+            Assert.Equal("emppseudo", user.Pseudo);
+            Assert.Equal("hashed", user.PasswordHash);
+            Assert.Equal(2, user.RoleId);
+            Assert.Same(role, user.Role);
+            Assert.False(user.IsSuspended);
+            Assert.False(user.MustChangePassword);
+        }
+    }
+}

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Services/CommentModerationServiceTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Services/CommentModerationServiceTests.cs
@@ -265,6 +265,11 @@ namespace FantasyRealm.Tests.Unit.Services
         [Fact]
         public async Task RejectAsync_WithEmptyReason_ReturnsFailure400()
         {
+            var comment = PendingComment();
+            _commentRepoMock
+                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(comment);
+
             var result = await _sut.RejectAsync(1, "", ReviewerId, CancellationToken.None);
 
             result.IsFailure.Should().BeTrue();
@@ -274,6 +279,11 @@ namespace FantasyRealm.Tests.Unit.Services
         [Fact]
         public async Task RejectAsync_WithReasonTooShort_ReturnsFailure400()
         {
+            var comment = PendingComment();
+            _commentRepoMock
+                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(comment);
+
             var result = await _sut.RejectAsync(1, "Court", ReviewerId, CancellationToken.None);
 
             result.IsFailure.Should().BeTrue();
@@ -283,6 +293,11 @@ namespace FantasyRealm.Tests.Unit.Services
         [Fact]
         public async Task RejectAsync_WithReasonTooLong_ReturnsFailure400()
         {
+            var comment = PendingComment();
+            _commentRepoMock
+                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(comment);
+
             var longReason = new string('x', 501);
             var result = await _sut.RejectAsync(1, longReason, ReviewerId, CancellationToken.None);
 


### PR DESCRIPTION
## Summary

- Introduce `DomainException` pour encapsuler les violations d'invariants métier dans le domaine
- Enrichir les entités `User`, `Character` et `Comment` avec des méthodes de domaine et des factory methods
- Protéger les propriétés mutables avec `internal set` + `InternalsVisibleTo` pour les projets de test
- Refactorer 6 services (Auth, Character, Moderation, CommentModeration, UserModeration, EmployeeManagement) en orchestrateurs qui délèguent la logique métier aux entités
- Ajouter 24 tests unitaires d'entités purs (sans mocks) et adapter les tests de services existants
- 413 tests passent (311 unit + 102 integration)

## Test plan

- [x] `dotnet build` compile sans erreur
- [x] `dotnet test` — 413 tests passent (311 unit + 102 integration)
- [x] Docker rebuild + test E2E : login admin, créer/suspendre/réactiver employé
- [x] Test E2E : login user, créer/soumettre/modifier personnage
- [x] Test E2E : login employee, approuver/rejeter personnage + commentaire
- [x] Test E2E : forgot password + changement de mot de passe

Closes #129