### PR TITLE
feat(frontend): handle JWT expiration with auto-logout (#107)

### DIFF
--- a/src/frontend/src/context/AuthContext.test.tsx
+++ b/src/frontend/src/context/AuthContext.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AuthProvider, useAuth } from './AuthContext';
+import { apiClient } from '../services/api';
 import type { LoginResponse } from '../services/authService';
 
 const TOKEN_KEY = 'fantasyrealm_token';
@@ -217,6 +218,70 @@ describe('AuthContext', () => {
       }).toThrow('useAuth must be used within an AuthProvider');
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe('JWT expiration handler registration', () => {
+    it('should register an unauthorized handler on apiClient at mount', () => {
+      const setHandlerSpy = vi.spyOn(apiClient, 'setUnauthorizedHandler');
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      expect(setHandlerSpy).toHaveBeenCalledTimes(1);
+      expect(setHandlerSpy).toHaveBeenCalledWith(expect.any(Function));
+
+      setHandlerSpy.mockRestore();
+    });
+
+    it('should clear localStorage and redirect when handler is invoked', () => {
+      const storedUser = { id: 1, email: 'a@a.com', pseudo: 'X', role: 'User' };
+      localStorage.setItem(TOKEN_KEY, 'some-token');
+      localStorage.setItem(USER_KEY, JSON.stringify(storedUser));
+
+      let capturedHandler: (() => void) | null = null;
+      const setHandlerSpy = vi
+        .spyOn(apiClient, 'setUnauthorizedHandler')
+        .mockImplementation((handler) => {
+          capturedHandler = handler;
+        });
+
+      const originalLocation = window.location;
+      const hrefSetter = vi.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...originalLocation,
+          set href(value: string) {
+            hrefSetter(value);
+          },
+          get href() {
+            return originalLocation.href;
+          },
+        },
+      });
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      expect(capturedHandler).not.toBeNull();
+      capturedHandler!();
+
+      expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+      expect(localStorage.getItem(USER_KEY)).toBeNull();
+      expect(hrefSetter).toHaveBeenCalledWith('/login?expired=true');
+
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+      setHandlerSpy.mockRestore();
     });
   });
 });

--- a/src/frontend/src/context/AuthContext.tsx
+++ b/src/frontend/src/context/AuthContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { apiClient } from '../services/api';
 import type { UserInfo, LoginResponse } from '../services/authService';
 
 const TOKEN_KEY = 'fantasyrealm_token';
@@ -39,6 +40,14 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
   const initialState = getInitialState();
   const [user, setUser] = useState<UserInfo | null>(initialState.user);
   const [token, setToken] = useState<string | null>(initialState.token);
+
+  useEffect(() => {
+    apiClient.setUnauthorizedHandler(() => {
+      localStorage.removeItem(TOKEN_KEY);
+      localStorage.removeItem(USER_KEY);
+      window.location.href = '/login?expired=true';
+    });
+  }, []);
 
   const login = (response: LoginResponse) => {
     localStorage.setItem(TOKEN_KEY, response.token);

--- a/src/frontend/src/pages/LoginPage.test.tsx
+++ b/src/frontend/src/pages/LoginPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter, BrowserRouter } from 'react-router-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import LoginPage from './LoginPage';
 import { authService } from '../services/authService';
@@ -34,6 +34,10 @@ const mockAuthLogin = vi.mocked(authService.login);
 
 const renderWithRouter = (component: React.ReactNode) => {
   return render(<BrowserRouter>{component}</BrowserRouter>);
+};
+
+const renderWithQuery = (component: React.ReactNode, search: string) => {
+  return render(<MemoryRouter initialEntries={[`/login${search}`]}>{component}</MemoryRouter>);
 };
 
 describe('LoginPage', () => {
@@ -156,6 +160,55 @@ describe('LoginPage', () => {
   describe('accessibility (RGAA/WCAG)', () => {
     it('should have no accessibility violations on initial render', async () => {
       const { container } = renderWithRouter(<LoginPage />);
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe('session expired banner', () => {
+    it('should NOT display the banner when no expired query param is present', () => {
+      renderWithQuery(<LoginPage />, '');
+
+      expect(screen.queryByText(/votre session a expiré/i)).not.toBeInTheDocument();
+    });
+
+    it('should NOT display the banner when expired query param is missing', () => {
+      renderWithQuery(<LoginPage />, '?other=true');
+
+      expect(screen.queryByText(/votre session a expiré/i)).not.toBeInTheDocument();
+    });
+
+    it('should display the banner when ?expired=true is present', () => {
+      renderWithQuery(<LoginPage />, '?expired=true');
+
+      expect(screen.getByText(/votre session a expiré/i)).toBeInTheDocument();
+      expect(screen.getByText(/veuillez vous reconnecter/i)).toBeInTheDocument();
+    });
+
+    it('should NOT display the banner when expired query param is not exactly "true"', () => {
+      renderWithQuery(<LoginPage />, '?expired=false');
+
+      expect(screen.queryByText(/votre session a expiré/i)).not.toBeInTheDocument();
+    });
+
+    it('should expose the banner as an accessible alert', () => {
+      renderWithQuery(<LoginPage />, '?expired=true');
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(/votre session a expiré/i);
+      expect(alert).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('should still render the login form when banner is shown', () => {
+      renderWithQuery(<LoginPage />, '?expired=true');
+
+      expect(screen.getByLabelText(/adresse email/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /se connecter/i })).toBeInTheDocument();
+    });
+
+    it('should have no accessibility violations when banner is shown', async () => {
+      const { container } = renderWithQuery(<LoginPage />, '?expired=true');
 
       const results = await axe(container);
       expect(results).toHaveNoViolations();

--- a/src/frontend/src/pages/LoginPage.tsx
+++ b/src/frontend/src/pages/LoginPage.tsx
@@ -1,9 +1,11 @@
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { Header, Footer } from '../components/layout';
 import { LoginForm } from '../components/auth';
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const sessionExpired = searchParams.get('expired') === 'true';
 
   const handleSuccess = () => {
     navigate('/dashboard');
@@ -32,6 +34,34 @@ const LoginPage = () => {
           </div>
 
           <div className="bg-dark-800 border border-dark-700 rounded-xl p-6 md:p-8">
+            {sessionExpired && (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="mb-6 p-4 bg-amber-900/30 border border-amber-700 rounded-lg flex items-start gap-3"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+                  />
+                </svg>
+                <div>
+                  <p className="text-amber-200 font-medium">Votre session a expiré.</p>
+                  <p className="text-amber-300/80 text-sm">Veuillez vous reconnecter.</p>
+                </div>
+              </div>
+            )}
+
             <LoginForm onSuccess={handleSuccess} />
 
             <div className="mt-6 pt-6 border-t border-dark-700 text-center">

--- a/src/frontend/src/services/api.test.ts
+++ b/src/frontend/src/services/api.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { apiClient, type ApiError } from './api';
+
+const originalFetch = globalThis.fetch;
+
+const mockFetchResponse = (status: number, body: unknown = {}): Response => {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+};
+
+describe('ApiClient — unauthorized handler', () => {
+  let unauthorizedHandler: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    unauthorizedHandler = vi.fn<() => void>();
+    apiClient.setUnauthorizedHandler(unauthorizedHandler);
+    // Reset internal isHandlingUnauthorized flag by calling it once and re-registering
+    // since the singleton persists across tests.
+    // We achieve this by registering a fresh handler each test.
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  describe('triggers handler on 401 for protected endpoints', () => {
+    it('should call handler when GET on protected endpoint returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401, { message: 'Token expired' }));
+
+      await expect(apiClient.getAuthenticated('/characters', 'expired-token')).rejects.toMatchObject({
+        status: 401,
+      });
+
+      expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call handler when POST on protected endpoint returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401, { message: 'Token expired' }));
+
+      await expect(
+        apiClient.postAuthenticated('/characters', { name: 'Test' }, 'expired-token')
+      ).rejects.toMatchObject({ status: 401 });
+
+      expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call handler when DELETE on protected endpoint returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401));
+
+      await expect(apiClient.deleteAuthenticated('/characters/1', 'expired-token')).rejects.toMatchObject({
+        status: 401,
+      });
+
+      expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('does NOT trigger handler on 401 for public auth endpoints', () => {
+    it('should NOT call handler when /auth/login returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(401, { message: 'Identifiants incorrects' })
+      );
+
+      await expect(
+        apiClient.post('/auth/login', { email: 'a@a.com', password: 'wrong' })
+      ).rejects.toMatchObject({ status: 401 });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call handler when /auth/register returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        mockFetchResponse(401, { message: 'Unauthorized' })
+      );
+
+      await expect(
+        apiClient.post('/auth/register', { email: 'a@a.com', password: 'pwd' })
+      ).rejects.toMatchObject({ status: 401 });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('does NOT trigger handler on non-401 errors', () => {
+    it('should NOT call handler on 400 Bad Request', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(400, { message: 'Validation error' }));
+
+      await expect(apiClient.getAuthenticated('/characters', 'token')).rejects.toMatchObject({
+        status: 400,
+      });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call handler on 403 Forbidden', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(403, { message: 'Forbidden' }));
+
+      await expect(apiClient.getAuthenticated('/admin/logs', 'token')).rejects.toMatchObject({
+        status: 403,
+      });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call handler on 500 Server Error', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(500, { message: 'Internal error' }));
+
+      await expect(apiClient.getAuthenticated('/characters', 'token')).rejects.toMatchObject({
+        status: 500,
+      });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error throwing behaviour', () => {
+    it('should still throw the ApiError after triggering handler', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401, { message: 'Custom expired msg' }));
+
+      try {
+        await apiClient.getAuthenticated('/characters', 'token');
+        expect.fail('Expected request to throw');
+      } catch (err) {
+        const apiError = err as ApiError;
+        expect(apiError.status).toBe(401);
+        expect(apiError.message).toBe('Custom expired msg');
+      }
+    });
+
+    it('should use generic message when API returns no message', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401));
+
+      await expect(apiClient.getAuthenticated('/characters', 'token')).rejects.toMatchObject({
+        status: 401,
+        message: 'Une erreur est survenue',
+      });
+    });
+  });
+
+  describe('network errors', () => {
+    it('should throw network error without calling handler when fetch fails', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('Network down'));
+
+      await expect(apiClient.getAuthenticated('/characters', 'token')).rejects.toMatchObject({
+        status: 0,
+      });
+
+      expect(unauthorizedHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reentrance protection', () => {
+    it('should call handler only once when multiple parallel 401 responses occur', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValueOnce(mockFetchResponse(401))
+        .mockResolvedValueOnce(mockFetchResponse(401))
+        .mockResolvedValueOnce(mockFetchResponse(401));
+
+      await Promise.allSettled([
+        apiClient.getAuthenticated('/a', 'token'),
+        apiClient.getAuthenticated('/b', 'token'),
+        apiClient.getAuthenticated('/c', 'token'),
+      ]);
+
+      expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reset reentrance flag when a new handler is registered', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401));
+      await expect(apiClient.getAuthenticated('/a', 'token')).rejects.toMatchObject({ status: 401 });
+      expect(unauthorizedHandler).toHaveBeenCalledTimes(1);
+
+      const secondHandler = vi.fn<() => void>();
+      apiClient.setUnauthorizedHandler(secondHandler);
+
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(mockFetchResponse(401));
+      await expect(apiClient.getAuthenticated('/b', 'token')).rejects.toMatchObject({ status: 401 });
+
+      expect(secondHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/frontend/src/services/api.ts
+++ b/src/frontend/src/services/api.ts
@@ -6,12 +6,31 @@ interface ApiError {
 }
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+type UnauthorizedHandler = () => void;
 
 class ApiClient {
   private baseUrl: string;
+  private onUnauthorized: UnauthorizedHandler | null = null;
+  private isHandlingUnauthorized = false;
+
+  private static readonly PUBLIC_AUTH_ENDPOINTS: ReadonlyArray<string> = [
+    '/auth/login',
+    '/auth/register',
+  ];
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
+  }
+
+  setUnauthorizedHandler(handler: UnauthorizedHandler): void {
+    this.onUnauthorized = handler;
+    this.isHandlingUnauthorized = false;
+  }
+
+  private shouldTriggerUnauthorizedHandler(endpoint: string): boolean {
+    return !ApiClient.PUBLIC_AUTH_ENDPOINTS.some((publicEndpoint) =>
+      endpoint.startsWith(publicEndpoint)
+    );
   }
 
   private async request(
@@ -46,6 +65,15 @@ class ApiClient {
     }
 
     if (!response.ok) {
+      if (
+        response.status === 401 &&
+        this.shouldTriggerUnauthorizedHandler(endpoint) &&
+        !this.isHandlingUnauthorized
+      ) {
+        this.isHandlingUnauthorized = true;
+        this.onUnauthorized?.();
+      }
+
       const errorData = await response.json().catch(() => ({}));
       const error: ApiError = {
         message: errorData.message || 'Une erreur est survenue',


### PR DESCRIPTION
## Résumé

Closes #107.

Lorsque le token JWT expire, l'utilisateur reçoit désormais un message clair "Votre session a expiré" et est redirigé vers la page de connexion, au lieu d'une erreur générique "Une erreur est survenue".

- **`apiClient`** : intercepte les `401` sur les endpoints protégés, déclenche un handler enregistré par l'`AuthProvider`. Les endpoints `/auth/login` et `/auth/register` sont exclus (un 401 sur login = mauvais mot de passe, pas une expiration).
- **`AuthContext`** : enregistre au mount un handler qui purge le `localStorage` puis fait `window.location.href = '/login?expired=true'`.
- **`LoginPage`** : affiche un bandeau d'avertissement accessible (`role="alert"`, `aria-live="polite"`) quand le query param est présent.
- **Anti-réentrance** : un flag interne garantit qu'une seule redirection est déclenchée même si plusieurs requêtes parallèles reçoivent 401.

## Tests

- Nouveau fichier `src/services/api.test.ts` (13 tests) — intercepteur, exclusions, anti-réentrance, throw conservé, erreurs réseau
- `src/context/AuthContext.test.tsx` — +2 tests sur l'enregistrement du handler et son comportement
- `src/pages/LoginPage.test.tsx` — +7 tests sur le bandeau (présence, query param, accessibilité axe)
- **Total : 513/513 tests passent** (491 avant, +22)

## Vérifications CI

- ✅ `npm run type-check` — 0 erreur
- ✅ `npm run lint` — 0 warning
- ✅ `npm run test` — 513/513 passent
- ✅ `npm run build` — build production OK

## Test plan

- [ ] Se connecter avec un compte de test
- [ ] Modifier manuellement la valeur de `fantasyrealm_token` dans le localStorage par un token invalide/expiré
- [ ] Effectuer une action authentifiée (charger le dashboard, créer un personnage)
- [ ] Vérifier la redirection vers `/login?expired=true`
- [ ] Vérifier l'affichage du bandeau ambre "Votre session a expiré"
- [ ] Vérifier que la connexion avec un mauvais mot de passe sur `/login` n'affiche PAS le bandeau (juste l'erreur classique)