### PR TITLE
feat(#133): équipement des personnages

### DIFF
--- a/src/backend/src/FantasyRealm.Api/Controllers/CharactersController.cs
+++ b/src/backend/src/FantasyRealm.Api/Controllers/CharactersController.cs
@@ -13,7 +13,9 @@ namespace FantasyRealm.Api.Controllers
     [ApiController]
     [Route("api/[controller]")]
     [Authorize(Policy = "RequireUser")]
-    public sealed class CharactersController(ICharacterService characterService) : ControllerBase
+    public sealed class CharactersController(
+        ICharacterService characterService,
+        ICharacterEquipmentService equipmentService) : ControllerBase
     {
         /// <summary>
         /// Creates a new character for the authenticated user.
@@ -291,6 +293,87 @@ namespace FantasyRealm.Api.Controllers
                 return StatusCode(result.ErrorCode ?? 400, new { message = result.Error });
 
             return Ok(result.Value);
+        }
+
+        /// <summary>
+        /// Returns the current equipment of a character.
+        /// </summary>
+        /// <param name="id">The character identifier.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="200">Equipment retrieved successfully.</response>
+        /// <response code="403">The authenticated user is not the owner.</response>
+        /// <response code="404">Character not found.</response>
+        [HttpGet("{id:int}/equipment")]
+        [ProducesResponseType(typeof(IReadOnlyList<EquippedArticleResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetEquipment(int id, CancellationToken cancellationToken)
+        {
+            if (!TryGetUserId(out var userId))
+                return Unauthorized(new { message = "Token invalide." });
+
+            var result = await equipmentService.GetEquipmentAsync(id, userId, cancellationToken);
+
+            if (result.IsFailure)
+                return StatusCode(result.ErrorCode ?? 400, new { message = result.Error });
+
+            return Ok(result.Value);
+        }
+
+        /// <summary>
+        /// Equips an article on a character, replacing any existing article in the same slot.
+        /// </summary>
+        /// <param name="id">The character identifier.</param>
+        /// <param name="articleId">The article identifier to equip.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Article equipped successfully.</response>
+        /// <response code="400">Article is inactive or domain rule violated.</response>
+        /// <response code="403">The authenticated user is not the owner.</response>
+        /// <response code="404">Character or article not found.</response>
+        [HttpPost("{id:int}/equipment/{articleId:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> EquipArticle(int id, int articleId, CancellationToken cancellationToken)
+        {
+            if (!TryGetUserId(out var userId))
+                return Unauthorized(new { message = "Token invalide." });
+
+            var result = await equipmentService.EquipArticleAsync(id, articleId, userId, cancellationToken);
+
+            if (result.IsFailure)
+                return StatusCode(result.ErrorCode ?? 400, new { message = result.Error });
+
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Unequips an article from a character.
+        /// </summary>
+        /// <param name="id">The character identifier.</param>
+        /// <param name="articleId">The article identifier to unequip.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <response code="204">Article unequipped successfully.</response>
+        /// <response code="400">Article is not equipped on this character.</response>
+        /// <response code="403">The authenticated user is not the owner.</response>
+        /// <response code="404">Character not found.</response>
+        [HttpDelete("{id:int}/equipment/{articleId:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> UnequipArticle(int id, int articleId, CancellationToken cancellationToken)
+        {
+            if (!TryGetUserId(out var userId))
+                return Unauthorized(new { message = "Token invalide." });
+
+            var result = await equipmentService.UnequipArticleAsync(id, articleId, userId, cancellationToken);
+
+            if (result.IsFailure)
+                return StatusCode(result.ErrorCode ?? 400, new { message = result.Error });
+
+            return NoContent();
         }
 
         private bool TryGetUserId(out int userId)

--- a/src/backend/src/FantasyRealm.Application/DTOs/EquippedArticleResponse.cs
+++ b/src/backend/src/FantasyRealm.Application/DTOs/EquippedArticleResponse.cs
@@ -1,0 +1,19 @@
+namespace FantasyRealm.Application.DTOs
+{
+    /// <summary>
+    /// Represents an article currently equipped on a character.
+    /// </summary>
+    /// <param name="ArticleId">The article identifier.</param>
+    /// <param name="Name">The article display name.</param>
+    /// <param name="SlotId">The equipment slot identifier.</param>
+    /// <param name="SlotName">The equipment slot display name.</param>
+    /// <param name="TypeId">The article type identifier.</param>
+    /// <param name="TypeName">The article type display name.</param>
+    public record EquippedArticleResponse(
+        int ArticleId,
+        string Name,
+        int SlotId,
+        string SlotName,
+        int TypeId,
+        string TypeName);
+}

--- a/src/backend/src/FantasyRealm.Application/Interfaces/ICharacterEquipmentService.cs
+++ b/src/backend/src/FantasyRealm.Application/Interfaces/ICharacterEquipmentService.cs
@@ -1,0 +1,48 @@
+using FantasyRealm.Application.Common;
+using FantasyRealm.Application.DTOs;
+
+namespace FantasyRealm.Application.Interfaces
+{
+    /// <summary>
+    /// Contract for character equipment operations (equip, unequip, list).
+    /// </summary>
+    public interface ICharacterEquipmentService
+    {
+        /// <summary>
+        /// Returns the list of articles currently equipped on a character.
+        /// </summary>
+        /// <param name="characterId">The character identifier.</param>
+        /// <param name="userId">The requesting user identifier (must be the owner).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<Result<IReadOnlyList<EquippedArticleResponse>>> GetEquipmentAsync(
+            int characterId,
+            int userId,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Equips an active article on a character, replacing any existing article in the same slot.
+        /// </summary>
+        /// <param name="characterId">The character identifier.</param>
+        /// <param name="articleId">The article identifier to equip.</param>
+        /// <param name="userId">The requesting user identifier (must be the owner).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<Result<bool>> EquipArticleAsync(
+            int characterId,
+            int articleId,
+            int userId,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Unequips an article from a character.
+        /// </summary>
+        /// <param name="characterId">The character identifier.</param>
+        /// <param name="articleId">The article identifier to unequip.</param>
+        /// <param name="userId">The requesting user identifier (must be the owner).</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        Task<Result<bool>> UnequipArticleAsync(
+            int characterId,
+            int articleId,
+            int userId,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/backend/src/FantasyRealm.Application/Interfaces/ICharacterRepository.cs
+++ b/src/backend/src/FantasyRealm.Application/Interfaces/ICharacterRepository.cs
@@ -68,6 +68,12 @@ namespace FantasyRealm.Application.Interfaces
             CancellationToken cancellationToken);
 
         /// <summary>
+        /// Returns a character by its identifier, including its full equipment with slot and type details.
+        /// Used by equipment operations and duplication to access the <see cref="Domain.Entities.CharacterArticle"/> collection.
+        /// </summary>
+        Task<Character?> GetByIdWithEquipmentAsync(int id, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Returns the total number of characters in the system.
         /// </summary>
         Task<int> CountAllAsync(CancellationToken cancellationToken);

--- a/src/backend/src/FantasyRealm.Application/Services/CharacterEquipmentService.cs
+++ b/src/backend/src/FantasyRealm.Application/Services/CharacterEquipmentService.cs
@@ -1,0 +1,99 @@
+using FantasyRealm.Application.Common;
+using FantasyRealm.Application.DTOs;
+using FantasyRealm.Application.Interfaces;
+using FantasyRealm.Domain.Exceptions;
+
+namespace FantasyRealm.Application.Services
+{
+    /// <summary>
+    /// Handles equipping and unequipping articles on player characters.
+    /// </summary>
+    public sealed class CharacterEquipmentService(
+        ICharacterRepository characterRepository,
+        IArticleRepository articleRepository) : ICharacterEquipmentService
+    {
+        /// <inheritdoc />
+        public async Task<Result<IReadOnlyList<EquippedArticleResponse>>> GetEquipmentAsync(
+            int characterId,
+            int userId,
+            CancellationToken cancellationToken)
+        {
+            var character = await characterRepository.GetByIdWithEquipmentAsync(characterId, cancellationToken);
+            if (character is null)
+                return Result<IReadOnlyList<EquippedArticleResponse>>.Failure("Personnage introuvable.", 404);
+
+            if (character.UserId != userId)
+                return Result<IReadOnlyList<EquippedArticleResponse>>.Failure("Accès non autorisé.", 403);
+
+            IReadOnlyList<EquippedArticleResponse> equipment = character.CharacterArticles
+                .Select(ca => new EquippedArticleResponse(
+                    ca.ArticleId,
+                    ca.Article.Name,
+                    ca.Article.SlotId,
+                    ca.Article.Slot.Name,
+                    ca.Article.TypeId,
+                    ca.Article.Type.Name))
+                .ToList();
+
+            return Result<IReadOnlyList<EquippedArticleResponse>>.Success(equipment);
+        }
+
+        /// <inheritdoc />
+        public async Task<Result<bool>> EquipArticleAsync(
+            int characterId,
+            int articleId,
+            int userId,
+            CancellationToken cancellationToken)
+        {
+            var character = await characterRepository.GetByIdWithEquipmentAsync(characterId, cancellationToken);
+            if (character is null)
+                return Result<bool>.Failure("Personnage introuvable.", 404);
+
+            if (character.UserId != userId)
+                return Result<bool>.Failure("Accès non autorisé.", 403);
+
+            var article = await articleRepository.GetByIdAsync(articleId, cancellationToken);
+            if (article is null || !article.IsActive)
+                return Result<bool>.Failure("Article introuvable ou inactif.", 404);
+
+            try
+            {
+                character.Equip(article);
+            }
+            catch (DomainException ex)
+            {
+                return Result<bool>.Failure(ex.Message, 400);
+            }
+
+            await characterRepository.UpdateAsync(character, cancellationToken);
+            return Result<bool>.Success(true);
+        }
+
+        /// <inheritdoc />
+        public async Task<Result<bool>> UnequipArticleAsync(
+            int characterId,
+            int articleId,
+            int userId,
+            CancellationToken cancellationToken)
+        {
+            var character = await characterRepository.GetByIdWithEquipmentAsync(characterId, cancellationToken);
+            if (character is null)
+                return Result<bool>.Failure("Personnage introuvable.", 404);
+
+            if (character.UserId != userId)
+                return Result<bool>.Failure("Accès non autorisé.", 403);
+
+            try
+            {
+                character.Unequip(articleId);
+            }
+            catch (DomainException ex)
+            {
+                return Result<bool>.Failure(ex.Message, 400);
+            }
+
+            await characterRepository.UpdateAsync(character, cancellationToken);
+            return Result<bool>.Success(true);
+        }
+    }
+}

--- a/src/backend/src/FantasyRealm.Application/Services/CharacterService.cs
+++ b/src/backend/src/FantasyRealm.Application/Services/CharacterService.cs
@@ -170,7 +170,7 @@ namespace FantasyRealm.Application.Services
             if (string.IsNullOrWhiteSpace(newName))
                 return Result<CharacterResponse>.Failure("Le nom est requis.", 400);
 
-            var character = await characterRepository.GetByIdAsync(characterId, cancellationToken);
+            var character = await characterRepository.GetByIdWithEquipmentAsync(characterId, cancellationToken);
             if (character is null)
                 return Result<CharacterResponse>.Failure("Personnage introuvable.", 404);
 
@@ -185,6 +185,9 @@ namespace FantasyRealm.Application.Services
                 return Result<CharacterResponse>.Failure("Vous avez déjà un personnage avec ce nom.", 409);
 
             var duplicate = Character.Duplicate(character, newName, userId);
+
+            foreach (var ca in character.CharacterArticles)
+                duplicate.CharacterArticles.Add(new Domain.Entities.CharacterArticle { ArticleId = ca.ArticleId });
 
             var created = await characterRepository.CreateAsync(duplicate, cancellationToken);
             return Result<CharacterResponse>.Success(CharacterMapper.ToResponse(created, character.Class.Name, true));

--- a/src/backend/src/FantasyRealm.Domain/Entities/Character.cs
+++ b/src/backend/src/FantasyRealm.Domain/Entities/Character.cs
@@ -120,6 +120,42 @@ namespace FantasyRealm.Domain.Entities
         }
 
         /// <summary>
+        /// Equips an article on the character, replacing any existing article occupying the same slot.
+        /// </summary>
+        /// <param name="article">The article to equip.</param>
+        /// <exception cref="DomainException">Thrown when the article is inactive.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when article navigations are not loaded.</exception>
+        public void Equip(Article article)
+        {
+            if (!article.IsActive)
+                throw new DomainException("Seuls les articles actifs peuvent être équipés.");
+
+            if (CharacterArticles.Any(ca => ca.Article is null))
+                throw new InvalidOperationException("CharacterArticles must be loaded with Article navigation before calling Equip().");
+
+            var existing = CharacterArticles.FirstOrDefault(ca => ca.Article.SlotId == article.SlotId);
+            if (existing is not null)
+                CharacterArticles.Remove(existing);
+
+            CharacterArticles.Add(new CharacterArticle { CharacterId = Id, ArticleId = article.Id });
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Unequips an article from the character by its identifier.
+        /// </summary>
+        /// <param name="articleId">The identifier of the article to remove.</param>
+        /// <exception cref="DomainException">Thrown when the article is not currently equipped.</exception>
+        public void Unequip(int articleId)
+        {
+            var existing = CharacterArticles.FirstOrDefault(ca => ca.ArticleId == articleId)
+                ?? throw new DomainException("Cet article n'est pas équipé sur ce personnage.");
+
+            CharacterArticles.Remove(existing);
+            UpdatedAt = DateTime.UtcNow;
+        }
+
+        /// <summary>
         /// Submits the character for moderation review.
         /// </summary>
         /// <exception cref="DomainException">Thrown when the character is not in a submittable state.</exception>

--- a/src/backend/src/FantasyRealm.Infrastructure/DependencyInjection.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/DependencyInjection.cs
@@ -72,6 +72,7 @@ namespace FantasyRealm.Infrastructure
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IEmployeeManagementService, EmployeeManagementService>();
             services.AddScoped<ICharacterService, CharacterService>();
+            services.AddScoped<ICharacterEquipmentService, CharacterEquipmentService>();
             services.AddScoped<ICommentService, CommentService>();
             services.AddScoped<ICommentModerationService, CommentModerationService>();
             services.AddScoped<IContactService, ContactService>();

--- a/src/backend/src/FantasyRealm.Infrastructure/Repositories/CharacterRepository.cs
+++ b/src/backend/src/FantasyRealm.Infrastructure/Repositories/CharacterRepository.cs
@@ -44,7 +44,9 @@ namespace FantasyRealm.Infrastructure.Repositories
         /// <inheritdoc />
         public async Task UpdateAsync(Character character, CancellationToken cancellationToken)
         {
-            context.Characters.Update(character);
+            if (context.Entry(character).State == Microsoft.EntityFrameworkCore.EntityState.Detached)
+                context.Characters.Update(character);
+
             await context.SaveChangesAsync(cancellationToken);
         }
 
@@ -157,6 +159,20 @@ namespace FantasyRealm.Infrastructure.Repositories
                 .ToListAsync(cancellationToken);
 
             return (items, totalCount);
+        }
+
+        /// <inheritdoc />
+        public async Task<Character?> GetByIdWithEquipmentAsync(int id, CancellationToken cancellationToken)
+        {
+            return await context.Characters
+                .Include(c => c.Class)
+                .Include(c => c.CharacterArticles)
+                    .ThenInclude(ca => ca.Article)
+                        .ThenInclude(a => a.Slot)
+                .Include(c => c.CharacterArticles)
+                    .ThenInclude(ca => ca.Article)
+                        .ThenInclude(a => a.Type)
+                .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/backend/tests/FantasyRealm.Tests.Unit/Services/CharacterServiceTests.cs
+++ b/src/backend/tests/FantasyRealm.Tests.Unit/Services/CharacterServiceTests.cs
@@ -501,7 +501,7 @@ namespace FantasyRealm.Tests.Unit.Services
             var character = CharacterWithClass();
             character.Status = CharacterStatus.Approved;
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(character);
             _characterRepoMock
                 .Setup(r => r.ExistsByNameAndUserAsync("NewHero", 10, null, It.IsAny<CancellationToken>()))
@@ -538,7 +538,7 @@ namespace FantasyRealm.Tests.Unit.Services
             var character = CharacterWithClass();
             character.Status = CharacterStatus.Approved;
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(character);
             _characterRepoMock
                 .Setup(r => r.ExistsByNameAndUserAsync("TakenName", 10, null, It.IsAny<CancellationToken>()))
@@ -556,7 +556,7 @@ namespace FantasyRealm.Tests.Unit.Services
             var character = CharacterWithClass();
             character.Status = CharacterStatus.Draft;
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(character);
 
             var result = await _sut.DuplicateAsync(1, 10, "NewHero", CancellationToken.None);
@@ -572,7 +572,7 @@ namespace FantasyRealm.Tests.Unit.Services
             var character = CharacterWithClass(userId: 99);
             character.Status = CharacterStatus.Approved;
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(character);
 
             var result = await _sut.DuplicateAsync(1, 10, "NewHero", CancellationToken.None);
@@ -585,7 +585,7 @@ namespace FantasyRealm.Tests.Unit.Services
         public async Task DuplicateAsync_WhenNotFound_Returns404()
         {
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Character?)null);
 
             var result = await _sut.DuplicateAsync(1, 10, "NewHero", CancellationToken.None);
@@ -609,7 +609,7 @@ namespace FantasyRealm.Tests.Unit.Services
             character.FaceShape = "carré";
 
             _characterRepoMock
-                .Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                .Setup(r => r.GetByIdWithEquipmentAsync(1, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(character);
             _characterRepoMock
                 .Setup(r => r.ExistsByNameAndUserAsync("CopiedHero", 10, null, It.IsAny<CancellationToken>()))

--- a/src/frontend/src/components/character/EquipmentPanel.tsx
+++ b/src/frontend/src/components/character/EquipmentPanel.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../../context/AuthContext';
+import { Modal, ModalHeader, ModalBody, Alert, Button } from '../ui';
+import { getEquipment, equipArticle, unequipArticle } from '../../services/characterService';
+import { getArticles } from '../../services/articleService';
+import { fetchEquipmentSlots, type EquipmentSlot } from '../../services/referenceDataService';
+import type { EquippedArticleResponse, ArticleSummaryResponse } from '../../types';
+
+interface EquipmentPanelProps {
+  characterId: number;
+  readOnly?: boolean;
+}
+
+const EquipmentPanel = ({ characterId, readOnly = false }: EquipmentPanelProps) => {
+  const { token } = useAuth();
+  const [equipment, setEquipment] = useState<EquippedArticleResponse[]>([]);
+  const [slots, setSlots] = useState<EquipmentSlot[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [activeSlot, setActiveSlot] = useState<EquipmentSlot | null>(null);
+  const [slotArticles, setSlotArticles] = useState<ArticleSummaryResponse[]>([]);
+  const [isLoadingArticles, setIsLoadingArticles] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const loadEquipment = useCallback(async () => {
+    if (!token) return;
+    const eq = await getEquipment(characterId, token);
+    setEquipment(eq);
+  }, [characterId, token]);
+
+  useEffect(() => {
+    if (!token) return;
+    setIsLoading(true);
+    Promise.all([getEquipment(characterId, token), fetchEquipmentSlots()])
+      .then(([eq, sl]) => {
+        setEquipment(eq);
+        setSlots([...sl].sort((a, b) => a.displayOrder - b.displayOrder));
+      })
+      .catch(() => setError("Impossible de charger l'équipement."))
+      .finally(() => setIsLoading(false));
+  }, [characterId, token]);
+
+  const handleOpenSlot = useCallback(
+    (slot: EquipmentSlot) => {
+      if (readOnly) return;
+      setActiveSlot(slot);
+      setSaveError(null);
+      setIsLoadingArticles(true);
+      getArticles(1, undefined, slot.id, undefined, 'nameAsc')
+        .then((res) => setSlotArticles(res.items))
+        .catch(() => setSlotArticles([]))
+        .finally(() => setIsLoadingArticles(false));
+    },
+    [readOnly]
+  );
+
+  const handleEquip = async (articleId: number) => {
+    if (!token || isSaving) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await equipArticle(characterId, articleId, token);
+      await loadEquipment();
+      setActiveSlot(null);
+    } catch {
+      setSaveError("Impossible d'équiper cet article.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleUnequip = async (articleId: number) => {
+    if (!token || isSaving) return;
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await unequipArticle(characterId, articleId, token);
+      await loadEquipment();
+      setActiveSlot(null);
+    } catch {
+      setSaveError("Impossible de retirer cet article.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const equippedForSlot = (slotId: number) =>
+    equipment.find((e) => e.slotId === slotId);
+
+  if (isLoading) {
+    return (
+      <section
+        aria-labelledby="equipment-heading"
+        className="mt-6 bg-dark-900/50 border border-dark-700 rounded-xl p-5"
+      >
+        <h2 id="equipment-heading" className="text-lg font-medium text-cream-100 mb-4">
+          Équipement
+        </h2>
+        <p className="text-cream-500 text-sm">Chargement…</p>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section
+        aria-labelledby="equipment-heading"
+        className="mt-6 bg-dark-900/50 border border-dark-700 rounded-xl p-5"
+      >
+        <h2 id="equipment-heading" className="text-lg font-medium text-cream-100 mb-4">
+          Équipement
+        </h2>
+        <Alert variant="error">{error}</Alert>
+      </section>
+    );
+  }
+
+  const activeEquipped = activeSlot ? equippedForSlot(activeSlot.id) : undefined;
+
+  return (
+    <>
+      <section
+        aria-labelledby="equipment-heading"
+        className="mt-6 bg-dark-900/50 border border-dark-700 rounded-xl p-5"
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <h2 id="equipment-heading" className="text-lg font-medium text-cream-100">
+            Équipement
+          </h2>
+          {!readOnly && (
+            <span className="text-xs text-cream-500">
+              Cliquez sur un slot pour équiper un article
+            </span>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-7 gap-3">
+          {slots.map((slot) => {
+            const equipped = equippedForSlot(slot.id);
+            return (
+              <button
+                key={slot.id}
+                type="button"
+                onClick={() => handleOpenSlot(slot)}
+                disabled={readOnly}
+                aria-label={`${slot.name}${equipped ? ` : ${equipped.name}` : ' : vide'}`}
+                className={[
+                  'flex flex-col items-center gap-1 p-3 rounded-lg border text-center transition-colors',
+                  readOnly
+                    ? 'cursor-default border-dark-700'
+                    : 'cursor-pointer hover:border-gold-500/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gold-500',
+                  equipped
+                    ? 'bg-dark-800 border-gold-500/30'
+                    : 'bg-dark-800/40 border-dark-700 border-dashed',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'w-10 h-10 rounded flex items-center justify-center',
+                    equipped ? 'bg-dark-700' : 'border-2 border-dashed border-dark-600',
+                  ].join(' ')}
+                  aria-hidden="true"
+                >
+                  {equipped ? (
+                    <span className="text-gold-400 text-base">✦</span>
+                  ) : (
+                    <span className="text-dark-500 text-xl">+</span>
+                  )}
+                </span>
+
+                {equipped ? (
+                  <>
+                    <span className="text-xs text-cream-200 font-medium leading-tight line-clamp-2 w-full">
+                      {equipped.name}
+                    </span>
+                    <span className="text-xs text-cream-500">{equipped.typeName}</span>
+                    <span className="text-xs text-gold-400/70 font-medium">{slot.name}</span>
+                  </>
+                ) : (
+                  <span className="text-xs text-cream-500 leading-tight">{slot.name}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {!readOnly && activeSlot && (
+        <Modal isOpen onClose={() => setActiveSlot(null)} size="xl">
+          <ModalHeader onClose={() => setActiveSlot(null)}>
+            Équiper — {activeSlot.name}
+          </ModalHeader>
+          <ModalBody>
+            {saveError && (
+              <Alert variant="error" className="mb-4">
+                {saveError}
+              </Alert>
+            )}
+
+            {activeEquipped && (
+              <div className="mb-4 flex items-center justify-between p-3 bg-dark-700 rounded-lg">
+                <div>
+                  <p className="text-xs text-cream-500 mb-0.5">Article équipé</p>
+                  <p className="text-cream-200 font-medium text-sm">{activeEquipped.name}</p>
+                  <p className="text-xs text-cream-500">{activeEquipped.typeName}</p>
+                </div>
+                <Button
+                  variant="secondary"
+                  onClick={() => handleUnequip(activeEquipped.articleId)}
+                  disabled={isSaving}
+                  aria-label={`Retirer ${activeEquipped.name}`}
+                >
+                  Retirer
+                </Button>
+              </div>
+            )}
+
+            {isLoadingArticles ? (
+              <p className="text-cream-500 text-sm py-6 text-center">Chargement des articles…</p>
+            ) : slotArticles.length === 0 ? (
+              <p className="text-cream-500 text-sm py-6 text-center">
+                Aucun article disponible pour ce slot.
+              </p>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 max-h-80 overflow-y-auto pr-1">
+                {slotArticles.map((article) => {
+                  const isEquipped = activeEquipped?.articleId === article.id;
+                  return (
+                    <button
+                      key={article.id}
+                      type="button"
+                      onClick={() => !isEquipped && handleEquip(article.id)}
+                      disabled={isSaving || isEquipped}
+                      aria-pressed={isEquipped}
+                      aria-label={`${isEquipped ? 'Équipé : ' : 'Équiper '}${article.name}`}
+                      className={[
+                        'flex flex-col items-center gap-2 p-3 rounded-lg border text-center transition-colors',
+                        'focus:outline-none focus-visible:ring-2 focus-visible:ring-gold-500',
+                        'disabled:opacity-50',
+                        isEquipped
+                          ? 'bg-gold-500/10 border-gold-500 cursor-default'
+                          : 'bg-dark-700 border-dark-600 hover:border-gold-500/50 cursor-pointer',
+                      ].join(' ')}
+                    >
+                      <div className="w-12 h-12 rounded bg-dark-800 flex items-center justify-center overflow-hidden">
+                        {article.imageBase64 ? (
+                          <img
+                            src={`data:image/png;base64,${article.imageBase64}`}
+                            alt=""
+                            className="w-full h-full object-contain"
+                          />
+                        ) : (
+                          <span className="text-dark-500 text-2xl" aria-hidden="true">
+                            ✦
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-xs text-cream-200 font-medium leading-tight line-clamp-2 w-full">
+                        {article.name}
+                      </span>
+                      <span className="text-xs text-cream-500">{article.typeName}</span>
+                      {isEquipped && (
+                        <span className="text-xs text-gold-400 font-medium">✓ Équipé</span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </ModalBody>
+        </Modal>
+      )}
+    </>
+  );
+};
+
+export default EquipmentPanel;

--- a/src/frontend/src/pages/CharacterDetailPage.test.tsx
+++ b/src/frontend/src/pages/CharacterDetailPage.test.tsx
@@ -19,6 +19,17 @@ vi.mock('../context/AuthContext', () => ({
 
 vi.mock('../services/characterService', () => ({
   getCharacterPublic: vi.fn(),
+  getEquipment: vi.fn().mockResolvedValue([]),
+  equipArticle: vi.fn().mockResolvedValue(undefined),
+  unequipArticle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/referenceDataService', () => ({
+  fetchEquipmentSlots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../services/articleService', () => ({
+  getArticles: vi.fn().mockResolvedValue({ items: [], totalCount: 0, page: 1, pageSize: 50, totalPages: 1 }),
 }));
 
 const mockCharacter: CharacterResponse = {

--- a/src/frontend/src/pages/CharacterDetailPage.tsx
+++ b/src/frontend/src/pages/CharacterDetailPage.tsx
@@ -7,6 +7,7 @@ import { Header, Footer } from '../components/layout';
 import { Button, Badge, Alert } from '../components/ui';
 import { EditIcon, CLASS_ICONS } from '../components/ui/icons';
 import { CharacterPreview } from '../components/character/CharacterPreview';
+import EquipmentPanel from '../components/character/EquipmentPanel';
 import { CommentSection } from '../components/comments';
 
 const STATUS_CONFIG: Record<string, { label: string; variant: 'default' | 'info' | 'success' | 'warning' | 'error' }> = {
@@ -228,6 +229,11 @@ export default function CharacterDetailPage() {
                       <ShapeDetail label="Bouche" value={character.mouthShape} labels={MOUTH_SHAPE_LABELS} />
                     </div>
                   </section>
+
+                  {/* Equipment section (owner only) */}
+                  {character.isOwner && (
+                    <EquipmentPanel characterId={character.id} readOnly />
+                  )}
 
                   {/* Actions */}
                   <div className="mt-8 pt-6 border-t border-dark-700 flex flex-wrap gap-3">

--- a/src/frontend/src/pages/CommentSection.test.tsx
+++ b/src/frontend/src/pages/CommentSection.test.tsx
@@ -43,6 +43,17 @@ vi.mock('../context/AuthContext', () => ({
 
 vi.mock('../services/characterService', () => ({
   getCharacterPublic: vi.fn(),
+  getEquipment: vi.fn().mockResolvedValue([]),
+  equipArticle: vi.fn().mockResolvedValue(undefined),
+  unequipArticle: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../services/referenceDataService', () => ({
+  fetchEquipmentSlots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../services/articleService', () => ({
+  getArticles: vi.fn().mockResolvedValue({ items: [], totalCount: 0, page: 1, pageSize: 50, totalPages: 1 }),
 }));
 
 vi.mock('../services/commentService', () => ({

--- a/src/frontend/src/pages/EditCharacterPage.test.tsx
+++ b/src/frontend/src/pages/EditCharacterPage.test.tsx
@@ -21,6 +21,11 @@ vi.mock('../services/referenceDataService', () => ({
   fetchCharacterClasses: vi.fn().mockResolvedValue([
     { id: 1, name: 'Guerrier', description: 'Un combattant robuste.', iconUrl: null },
   ]),
+  fetchEquipmentSlots: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../services/articleService', () => ({
+  getArticles: vi.fn().mockResolvedValue({ items: [], totalCount: 0, page: 1, pageSize: 50, totalPages: 1 }),
 }));
 
 vi.mock('../services/characterService', () => ({
@@ -28,6 +33,9 @@ vi.mock('../services/characterService', () => ({
   updateCharacter: vi.fn(),
   submitCharacter: vi.fn(),
   checkNameAvailability: vi.fn().mockResolvedValue({ available: true }),
+  getEquipment: vi.fn().mockResolvedValue([]),
+  equipArticle: vi.fn().mockResolvedValue(undefined),
+  unequipArticle: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockCharacter: CharacterResponse = {

--- a/src/frontend/src/pages/EditCharacterPage.tsx
+++ b/src/frontend/src/pages/EditCharacterPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Header, Footer } from '../components/layout';
 import { CharacterForm } from '../components/character';
+import EquipmentPanel from '../components/character/EquipmentPanel';
 import { getCharacter, updateCharacter, submitCharacter } from '../services/characterService';
 import type { CreateCharacterData, CharacterResponse } from '../types';
 import { useAuth } from '../context/AuthContext';
@@ -118,16 +119,19 @@ const EditCharacterPage = () => {
           )}
 
           {!isLoading && !error && character && (
-            <CharacterForm
-              initialData={mapToFormData(character)}
-              characterId={character.id}
-              characterStatus={character.status}
-              onSaveDraft={handleSave}
-              onSubmitToModeration={canSubmitToModeration ? handleSubmitToModeration : undefined}
-              isLoadingDraft={isLoadingDraft}
-              isLoadingSubmit={isLoadingSubmit}
-              mode="edit"
-            />
+            <>
+              <CharacterForm
+                initialData={mapToFormData(character)}
+                characterId={character.id}
+                characterStatus={character.status}
+                onSaveDraft={handleSave}
+                onSubmitToModeration={canSubmitToModeration ? handleSubmitToModeration : undefined}
+                isLoadingDraft={isLoadingDraft}
+                isLoadingSubmit={isLoadingSubmit}
+                mode="edit"
+              />
+              <EquipmentPanel characterId={character.id} />
+            </>
           )}
         </div>
       </main>

--- a/src/frontend/src/services/characterService.ts
+++ b/src/frontend/src/services/characterService.ts
@@ -4,6 +4,7 @@ import type {
   UpdateCharacterData,
   CharacterResponse,
   CharacterSummary,
+  EquippedArticleResponse,
   NameAvailabilityResponse,
   GalleryCharacter,
   GalleryFilters,
@@ -94,6 +95,33 @@ export const toggleShareCharacter = (
     `/characters/${id}/share`,
     token
   );
+
+export const getEquipment = (
+  id: number,
+  token: string
+): Promise<EquippedArticleResponse[]> =>
+  apiClient.getAuthenticated<EquippedArticleResponse[]>(
+    `/characters/${id}/equipment`,
+    token
+  );
+
+export const equipArticle = (
+  id: number,
+  articleId: number,
+  token: string
+): Promise<void> =>
+  apiClient.postAuthenticatedNoContent<Record<string, never>>(
+    `/characters/${id}/equipment/${articleId}`,
+    {} as Record<string, never>,
+    token
+  );
+
+export const unequipArticle = (
+  id: number,
+  articleId: number,
+  token: string
+): Promise<void> =>
+  apiClient.deleteAuthenticated(`/characters/${id}/equipment/${articleId}`, token);
 
 export const getGallery = (
   filters: GalleryFilters = {}

--- a/src/frontend/src/types/character-responses.ts
+++ b/src/frontend/src/types/character-responses.ts
@@ -39,3 +39,12 @@ export interface CharacterSummary {
 export interface NameAvailabilityResponse {
   available: boolean;
 }
+
+export interface EquippedArticleResponse {
+  articleId: number;
+  name: string;
+  slotId: number;
+  slotName: string;
+  typeId: number;
+  typeName: string;
+}


### PR DESCRIPTION
## Résumé

- **Backend** : endpoints `GET/POST/DELETE /characters/{id}/equipment`, service `CharacterEquipmentService`, méthodes domaine `Character.Equip()` / `Character.Unequip()`, `GetByIdWithEquipmentAsync` dans le repository
- **Frontend** : composant `EquipmentPanel` (sélection par slot, modal d'articles, retrait), intégré dans `EditCharacterPage` (éditable) et `CharacterDetailPage` (lecture seule)
- Correction : guard `EntityState.Detached` dans `UpdateAsync` pour éviter les UPDATE inutiles sur EF Core

## Plan de test

- [ ] Créer un personnage et accéder à la page de modification
- [ ] Cliquer sur un slot vide → vérifier l'ouverture de la modal avec les articles disponibles
- [ ] Équiper un article → vérifier qu'il apparaît dans le slot
- [ ] Équiper un article dans le même slot → vérifier le remplacement
- [ ] Retirer un article → vérifier que le slot redevient vide
- [ ] Accéder à la page de détail → vérifier l'affichage en lecture seule
- [ ] Tester les accès non-propriétaire → vérifier 403 sur les endpoints équipement